### PR TITLE
fix(memory): correct consolidation cursor/window semantics

### DIFF
--- a/tests/core/test_memory.py
+++ b/tests/core/test_memory.py
@@ -441,6 +441,36 @@ async def test_no_consolidation_above_threshold_if_cursor_covers_it(
     assert call_count == 0
 
 
+async def test_consolidation_triggers_multiple_times_over_long_run(
+    storage: InMemoryStorage,
+) -> None:
+    """Consolidation should continue to trigger as new turns accumulate."""
+    call_count = 0
+
+    class CountingLLM:
+        async def chat(self, messages: list[Message], tools: list, *, stream: bool = True):  # type: ignore[override]
+            nonlocal call_count
+            call_count += 1
+
+            async def _gen():
+                yield f"summary-{call_count}"
+
+            return _gen()
+
+    manager = MemoryManager(
+        storage=storage,
+        consolidation_threshold=4,
+        keep_recent_ratio=0.25,
+        llm=CountingLLM(),
+    )
+
+    for i in range(15):
+        await manager.build_messages("cli", "local", f"user {i}", "sys")
+        await manager.persist_exchange("cli", "local", f"user {i}", f"assistant {i}")
+
+    assert call_count >= 2
+
+
 async def test_global_memory_default_empty(storage: InMemoryStorage) -> None:
     doc = await storage.load_global_memory()
     assert doc == ""


### PR DESCRIPTION
## Summary
- fixes the consolidation trigger/cursor mismatch by basing consolidation decisions on full global history while still limiting prompt context to the recent window
- updates warning logic to use unconsolidated global message count so warnings stay consistent with consolidation behavior
- adds a regression test that reproduces the one-shot consolidation bug and verifies consolidation triggers multiple times over long runs

## Testing
- uv run pytest tests/core/test_memory.py::test_consolidation_triggers_multiple_times_over_long_run -v
- uv run pytest tests/core/test_memory.py -v
- uv run ruff check .
- uv run mypy squidbot/
- uv run pytest

Closes #7