### PR TITLE
chore(memory): align docs/tests with manual-only terminology

### DIFF
--- a/docs/plans/2026-02-24-global-history-design.md
+++ b/docs/plans/2026-02-24-global-history-design.md
@@ -78,18 +78,14 @@ Owner messages are identified via the `aliases` config and labelled uniformly as
 The system prompt layout is otherwise unchanged:
 
 ```
-system: [soul/identity/config] + [## Your Memory\n<MEMORY.md>] + [## Session Summary\n<summary.md>] + [<skills>]
+system: [soul/identity/config] + [## Your Memory\n<MEMORY.md>] + [<skills>]
 <labelled history messages>
 user: <current input>
 ```
 
 ## Consolidation
 
-Same logic as today, but global:
-
-- Single cursor in `history.meta.json`
-- Single `memory/summary.md` covering all channels
-- Summary injected into every system prompt (no longer per-session)
+Under the manual-only memory model, summary injection is not implemented: global recall relies on `MEMORY.md` for curated facts and on explicit `search_history` lookups when details fall outside the most recent N injected history messages.
 
 ## search_history Tool
 

--- a/tests/adapters/persistence/test_jsonl_global_memory.py
+++ b/tests/adapters/persistence/test_jsonl_global_memory.py
@@ -1,4 +1,4 @@
-"""Tests for JsonlMemory global memory and session summary persistence."""
+"""Tests for JsonlMemory global memory persistence."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Text-only terminology cleanup to match the manual-only global memory model.

Closes #5