### PR TITLE
style: fix formatting in memory.py and test_registry.py

### DIFF
--- a/squidbot/core/memory.py
+++ b/squidbot/core/memory.py
@@ -82,6 +82,7 @@ class MemoryManager:
         if (sender_id, channel) in self._scoped_aliases:
             return True
         return sender_id in self._unscoped_aliases
+
     def _label_message(self, msg: Message) -> Message:
         """
         Return a copy of msg with a channel/sender label prepended to content.

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -36,28 +36,30 @@ async def test_execute_unknown_tool_returns_error():
     result = await registry.execute("unknown_tool", tool_call_id="tc_1")
     assert result.is_error is True
     assert "unknown_tool" in result.content
+
+
 def test_get_definitions_caching():
     registry = ToolRegistry()
     registry.register(EchoTool())
-    
+
     # First call builds cache
     defs1 = registry.get_definitions()
     # Second call uses cache
     defs2 = registry.get_definitions()
-    
+
     assert defs1 == defs2
     assert defs1 is not defs2  # Should be a new list copy
-    
+
     # Mutation of returned list doesn't affect cache
     defs1.clear()
     assert len(registry.get_definitions()) == 1
-    
+
     # Invalidation on register
     class AnotherTool:
         name = "another"
         description = "Another tool"
         parameters = {"type": "object", "properties": {}}
-    
+
     registry.register(AnotherTool())
     defs3 = registry.get_definitions()
     assert len(defs3) == 2


### PR DESCRIPTION
## Summary

Fixes code formatting issues in `squidbot/core/memory.py` and `tests/core/test_registry.py` to make CI pass.

## Changes

- `squidbot/core/memory.py`: Added missing blank line
- `tests/core/test_registry.py`: Reformatted for consistent indentation

## Checklist

- [x] `uv run ruff format . --check` passes
- [x] `uv run ruff check .` passes