### PR TITLE
test: fix failing test by removing obsolete MarkdownIt patch

### DIFF
--- a/tests/adapters/channels/test_email.py
+++ b/tests/adapters/channels/test_email.py
@@ -421,14 +421,8 @@ class TestEmailChannelSend:
         ch = EmailChannel(config=config, tmp_dir=tmp_path)
         outbound = self._make_outbound(text="**bold**")
 
-        with (
-            patch("squidbot.adapters.channels.email.aiosmtplib.SMTP", return_value=fake_smtp),
-            patch("squidbot.adapters.channels.email.MarkdownIt") as markdown_it_cls,
-        ):
+        with patch("squidbot.adapters.channels.email.aiosmtplib.SMTP", return_value=fake_smtp):
             await ch.send(outbound)  # type: ignore[arg-type]
-
-        markdown_it_cls.assert_not_called()
-
         sent = fake_smtp.send_message.call_args[0][0]
         content_type = sent.get_content_type()
         assert content_type == "multipart/alternative"


### PR DESCRIPTION
## Problem

The CI pipeline was failing with:
```
AttributeError: module 'squidbot.adapters.channels.email' does not have the attribute 'MarkdownIt'
```

## Root Cause

The test `test_send_multipart_alternative` was patching `MarkdownIt`, but the actual implementation in `email.py` uses `mistune` instead. This mismatch caused the test to fail.

## Changes

- Removed the obsolete `MarkdownIt` patch from the test
- Removed the assertion checking that `MarkdownIt` was not called
- Test now only patches `aiosmtplib.SMTP` as needed

## Verification

```bash
uv run pytest tests/adapters/channels/test_email.py::TestEmailChannelSend::test_send_multipart_alternative -v
# 1 passed
```

This fix allows the CI pipeline to complete successfully.