### PR TITLE
ci: add Codecov token for authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   build-package:


### PR DESCRIPTION
## Changes

Add CODECOV_TOKEN secret to the codecov action for reliable coverage uploads.

## Why

While Codecov works without a token for public repositories, using a token is recommended for:
- More reliable uploads (avoids rate limiting)
- Better security posture
- Consistent behavior across all builds

## Setup Required

Repository owner needs to add the token in:
Settings -> Secrets and variables -> Actions -> New repository secret

Secret name: CODECOV_TOKEN
Secret value: Token from https://codecov.io/gh/Athemis/squidbot/settings