### PR TITLE
feat(cli): use prompt-toolkit for agent input

### DIFF
--- a/docs/plans/2026-02-28-agent-prompt-toolkit-design.md
+++ b/docs/plans/2026-02-28-agent-prompt-toolkit-design.md
@@ -1,0 +1,33 @@
+# Design: Prompt Toolkit Integration for CLI Channel
+
+## Objective
+Enhance the interactive CLI channel (`RichCliChannel`) by replacing the standard `input()`/`Prompt.ask()` with `prompt-toolkit` for asynchronous, non-blocking user input, while retaining `Rich` for all output rendering.
+
+## Architecture Choice
+- **Input:** Use `prompt-toolkit`'s `PromptSession.prompt_async()` wrapped with `patch_stdout`. This allows background tasks (like heartbeat or cron) to print to stdout without corrupting the input prompt.
+- **Output:** Keep `Rich` for all output (`Console().print(Markdown(...))`). `Rich` provides excellent Markdown rendering which is essential for the assistant's responses.
+- **Streaming Policy:**
+  - `streaming=False` for interactive mode (`RichCliChannel`). We collect the full response before sending it to `Rich` for proper Markdown rendering.
+  - `streaming=True` for single-message mode (`-m` flag, `CliChannel`). This remains unchanged.
+
+## File-Level Changes
+1. `squidbot/adapters/channels/cli.py`:
+   - Update `RichCliChannel` to use `prompt-toolkit`.
+   - Import `PromptSession` and `patch_stdout` from `prompt_toolkit`.
+   - Replace the synchronous `_prompt` thread executor with an asynchronous `prompt_async` call.
+2. `pyproject.toml` / `uv.lock`:
+   - Add `prompt-toolkit` as a dependency.
+
+## Error Handling
+- Handle `EOFError` and `KeyboardInterrupt` gracefully during `prompt_async()` to allow clean exits (Ctrl+D, Ctrl+C).
+- Ensure `patch_stdout` context manager correctly restores stdout state even if exceptions occur.
+
+## Testing Approach
+- Update `tests/adapters/channels/test_rich_cli.py` to mock `PromptSession.prompt_async` instead of `Prompt.ask`.
+- Verify that `EOFError` and `KeyboardInterrupt` trigger a clean exit.
+- Verify that standard text input yields an `InboundMessage`.
+
+## Non-Goals
+- **No multiline input:** The prompt will remain single-line.
+- **No persistent history:** We will not save prompt history across sessions.
+- **No full-screen UI:** The interface remains a standard scrolling terminal, not a full-screen TUI.

--- a/docs/plans/2026-02-28-agent-prompt-toolkit-implementation-plan.md
+++ b/docs/plans/2026-02-28-agent-prompt-toolkit-implementation-plan.md
@@ -8,7 +8,7 @@
 2. **Update `RichCliChannel` in `squidbot/adapters/channels/cli.py`:**
    - Import `PromptSession` and `patch_stdout` from `prompt_toolkit`.
    - Initialize a `PromptSession` instance in `RichCliChannel.__init__` (or lazily in `receive`).
-   - Modify the `receive` method to use `await self.session.prompt_async("You: ")` wrapped in an `async with patch_stdout():` block.
+   - Modify the `receive` method to use `await self.session.prompt_async("You: ")` wrapped in a `with patch_stdout():` block.
    - Remove the `_prompt` method and the `asyncio.to_thread` call, as `prompt_async` is natively asynchronous.
    - Ensure `EOFError` and `KeyboardInterrupt` are caught and handled by breaking the loop.
 

--- a/docs/plans/2026-02-28-agent-prompt-toolkit-implementation-plan.md
+++ b/docs/plans/2026-02-28-agent-prompt-toolkit-implementation-plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: Prompt Toolkit Integration for CLI Channel
+
+## Step-by-Step Implementation Order
+
+1. **Add Dependency:**
+   - Run `uv add prompt-toolkit` to add the dependency to `pyproject.toml` and update `uv.lock`.
+
+2. **Update `RichCliChannel` in `squidbot/adapters/channels/cli.py`:**
+   - Import `PromptSession` and `patch_stdout` from `prompt_toolkit`.
+   - Initialize a `PromptSession` instance in `RichCliChannel.__init__` (or lazily in `receive`).
+   - Modify the `receive` method to use `await self.session.prompt_async("You: ")` wrapped in an `async with patch_stdout():` block.
+   - Remove the `_prompt` method and the `asyncio.to_thread` call, as `prompt_async` is natively asynchronous.
+   - Ensure `EOFError` and `KeyboardInterrupt` are caught and handled by breaking the loop.
+
+3. **Update Tests:**
+   - Modify `tests/adapters/channels/test_rich_cli.py` to mock `PromptSession.prompt_async` instead of `Prompt.ask`.
+   - Ensure tests cover standard input, `EOFError`, and `KeyboardInterrupt`.
+
+4. **Quality Gates:**
+   - Run `uv run ruff check .` to ensure no linting errors.
+   - Run `uv run ruff format . --check` to ensure correct formatting.
+   - Run `uv run mypy squidbot/` to ensure type safety.
+   - Run `uv run pytest` to ensure all tests pass.
+
+## Testing Strategy
+- **Unit Tests:** Update existing tests for `RichCliChannel` to verify the new asynchronous prompt behavior.
+- **Manual Verification:** Run `squidbot agent` and verify that the prompt works correctly, accepts input, and exits cleanly on Ctrl+C/Ctrl+D.
+
+## Non-Goals
+- **No multiline input:** The prompt will remain single-line.
+- **No persistent history:** We will not save prompt history across sessions.
+- **No full-screen UI:** The interface remains a standard scrolling terminal, not a full-screen TUI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "mistune>=3.0",
     "aioimaplib>=1.0",
     "aiosmtplib>=3.0",
+    "prompt-toolkit>=3,<4",
 ]
 
 [project.scripts]

--- a/squidbot/adapters/channels/cli.py
+++ b/squidbot/adapters/channels/cli.py
@@ -20,6 +20,8 @@ from rich.rule import Rule
 
 from squidbot.core.models import InboundMessage, OutboundMessage, Session
 
+EXIT_COMMANDS = ("exit", "quit", "/exit", "/quit", ":q")
+
 
 class CliChannel:
     """
@@ -40,7 +42,7 @@ class CliChannel:
                 if line is None:
                     break
                 text = line.strip()
-                if text.lower() in ("exit", "quit", "/exit", "/quit", ":q"):
+                if text.lower() in EXIT_COMMANDS:
                     break
                 if text:
                     yield InboundMessage(session=self.SESSION, text=text)
@@ -93,7 +95,7 @@ class RichCliChannel:
             try:
                 with patch_stdout():
                     text = (await self._get_session().prompt_async()).strip()
-                if text.lower() in ("exit", "quit", "/exit", "/quit", ":q"):
+                if text.lower() in EXIT_COMMANDS:
                     break
                 if text:
                     yield InboundMessage(session=self.SESSION, text=text)

--- a/tests/adapters/channels/test_rich_cli.py
+++ b/tests/adapters/channels/test_rich_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from rich.markdown import Markdown
+from rich.markdown import Markdown  # pyright: ignore[reportMissingImports]
 
 from squidbot.adapters.channels.cli import RichCliChannel
 from squidbot.core.models import OutboundMessage, Session
@@ -55,11 +55,10 @@ class TestRichCliChannelReceive:
         """receive() should yield an InboundMessage for non-empty, non-exit input."""
         ch = RichCliChannel()
 
-        with patch(
-            "squidbot.adapters.channels.cli.asyncio.to_thread", new_callable=AsyncMock
-        ) as mock_thread:
-            # First call returns a message, second raises EOFError to end the loop
-            mock_thread.side_effect = ["Hello world", EOFError()]
+        with patch("squidbot.adapters.channels.cli.PromptSession") as mock_prompt_session_class:
+            mock_prompt_session = MagicMock()
+            mock_prompt_session.prompt_async = AsyncMock(side_effect=["Hello world", EOFError()])
+            mock_prompt_session_class.return_value = mock_prompt_session
 
             messages = []
             async for msg in ch.receive():
@@ -73,10 +72,10 @@ class TestRichCliChannelReceive:
         """receive() should skip blank lines."""
         ch = RichCliChannel()
 
-        with patch(
-            "squidbot.adapters.channels.cli.asyncio.to_thread", new_callable=AsyncMock
-        ) as mock_thread:
-            mock_thread.side_effect = ["   ", "Hi", EOFError()]
+        with patch("squidbot.adapters.channels.cli.PromptSession") as mock_prompt_session_class:
+            mock_prompt_session = MagicMock()
+            mock_prompt_session.prompt_async = AsyncMock(side_effect=["   ", "Hi", EOFError()])
+            mock_prompt_session_class.return_value = mock_prompt_session
 
             messages = []
             async for msg in ch.receive():
@@ -86,14 +85,15 @@ class TestRichCliChannelReceive:
         assert messages[0].text == "Hi"
 
     @pytest.mark.asyncio
-    async def test_receive_stops_on_exit(self):
-        """receive() should stop when user types 'exit'."""
+    @pytest.mark.parametrize("command", ["exit", "quit", "/exit", "/quit", ":q"])
+    async def test_receive_stops_on_exit_variants(self, command: str):
+        """receive() should stop for all configured exit commands."""
         ch = RichCliChannel()
 
-        with patch(
-            "squidbot.adapters.channels.cli.asyncio.to_thread", new_callable=AsyncMock
-        ) as mock_thread:
-            mock_thread.side_effect = ["exit"]
+        with patch("squidbot.adapters.channels.cli.PromptSession") as mock_prompt_session_class:
+            mock_prompt_session = MagicMock()
+            mock_prompt_session.prompt_async = AsyncMock(side_effect=[command])
+            mock_prompt_session_class.return_value = mock_prompt_session
 
             messages = []
             async for msg in ch.receive():
@@ -102,17 +102,40 @@ class TestRichCliChannelReceive:
         assert messages == []
 
     @pytest.mark.asyncio
-    async def test_receive_stops_on_quit(self):
-        """receive() should stop when user types 'quit'."""
+    async def test_receive_stops_on_keyboard_interrupt(self):
+        """receive() should stop when prompt input is interrupted."""
         ch = RichCliChannel()
 
-        with patch(
-            "squidbot.adapters.channels.cli.asyncio.to_thread", new_callable=AsyncMock
-        ) as mock_thread:
-            mock_thread.side_effect = ["quit"]
+        with patch("squidbot.adapters.channels.cli.PromptSession") as mock_prompt_session_class:
+            mock_prompt_session = MagicMock()
+            mock_prompt_session.prompt_async = AsyncMock(side_effect=[KeyboardInterrupt()])
+            mock_prompt_session_class.return_value = mock_prompt_session
 
             messages = []
             async for msg in ch.receive():
                 messages.append(msg)
 
         assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_receive_uses_patch_stdout(self):
+        """receive() should prompt within prompt-toolkit patch_stdout()."""
+        ch = RichCliChannel()
+
+        with (
+            patch("squidbot.adapters.channels.cli.PromptSession") as mock_prompt_session_class,
+            patch("squidbot.adapters.channels.cli.patch_stdout") as mock_patch_stdout,
+        ):
+            mock_prompt_session = MagicMock()
+            mock_prompt_session.prompt_async = AsyncMock(side_effect=["Hello", EOFError()])
+            mock_prompt_session_class.return_value = mock_prompt_session
+
+            messages = []
+            async for msg in ch.receive():
+                messages.append(msg)
+
+        assert len(messages) == 1
+        assert messages[0].text == "Hello"
+        assert mock_patch_stdout.called
+        mock_patch_stdout.return_value.__enter__.assert_called()
+        mock_patch_stdout.return_value.__exit__.assert_called()

--- a/uv.lock
+++ b/uv.lock
@@ -917,6 +917,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1289,6 +1301,7 @@ dependencies = [
     { name = "mistune" },
     { name = "openai" },
     { name = "pillow" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -1318,6 +1331,7 @@ requires-dist = [
     { name = "mistune", specifier = ">=3.0" },
     { name = "openai", specifier = ">=2.0" },
     { name = "pillow", specifier = ">=10.0" },
+    { name = "prompt-toolkit", specifier = ">=3,<4" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -1411,6 +1425,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Scope
Switch RichCliChannel input to prompt-toolkit

## Non-goals
No multiline, no persistent history, no full-screen UI

## Quality gates passed
- ruff
- mypy
- pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous, non-blocking CLI input using a prompt session while preserving Rich output and existing streaming behavior.

* **Bug Fixes**
  * Improved handling of EOF and keyboard interrupts for clean exits; ensures stdout state is restored on errors.

* **Tests**
  * Updated tests to mock the new async prompt flow, expanded exit-case coverage, and verify stdout patching.

* **Chores**
  * Added prompt-toolkit to project dependencies; added implementation/design docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->