### PR TITLE
docs: reconcile design doc with current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ uv tool install --reinstall /home/alex/git/squidbot
 - `rich` -> `/Textualize/rich`
 - `loguru` -> `/Delgan/loguru`
 - `Pillow` -> `/python-pillow/Pillow`
-- `markdown-it-py` -> `/lepture/markdown-it-py`
+- `mistune` -> `/lepture/mistune`
 - `aioimaplib` -> `/kksilicon/aioimaplib`
 - `aiosmtplib` -> `/aio-libs/aiosmtplib`
 - `openclaw` -> `/openclaw/openclaw`


### PR DESCRIPTION
## Summary

- **Technology Stack corrected:** `markdown-it-py` → `mistune` (actual runtime dependency); same fix in `AGENTS.md` Context7 library IDs
- **Tool Inventory section added:** New table listing all tool names (`read_file`, `write_file`, `list_files`, `spawn`, `spawn_await`, `cron_list`, `cron_add`, `cron_remove`, `cron_set_enabled`, etc.) replacing scattered inline mentions
- **Config defaults corrected:** `spawn.enabled: false`, `web_search.provider: "searxng"`, heartbeat `active_hours` `00:00`–`24:00`, heartbeat `prompt` field added
- **Bundled skills:** `[planned]` markers added for skills with placeholder content; note explaining `requires_bins`/`requires_env` exists in code but unused
- **Test structure expanded:** Representative file listings across all subdirectories
- **Changelog entry** added documenting all corrections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture design with enhanced memory management system supporting global history across channels.
  * Improved LLM integration capabilities with expanded reasoning and tool tracking.
  * Extended tool execution and skill discovery interfaces.
  * Enhanced status reporting system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->