### PR TITLE
fix(cron): reject non-positive interval schedules

### DIFF
--- a/squidbot/core/scheduler.py
+++ b/squidbot/core/scheduler.py
@@ -74,7 +74,9 @@ def parse_schedule(job: CronJob, now: datetime | None = None) -> datetime | None
     schedule = job.schedule.strip()
     if schedule.startswith("every "):
         try:
-            int(schedule.split()[1])
+            seconds = int(schedule.split()[1])
+            if seconds <= 0:
+                return None
             return now.replace(microsecond=0)
         except IndexError, ValueError:
             return None
@@ -105,6 +107,8 @@ def is_due(job: CronJob, now: datetime | None = None) -> bool:
     if schedule.startswith("every "):
         try:
             seconds = int(schedule.split()[1])
+            if seconds <= 0:
+                return False
             if job.last_run is None:
                 return True
             elapsed = (now - job.last_run).total_seconds()

--- a/tests/adapters/tools/test_cron_tools.py
+++ b/tests/adapters/tools/test_cron_tools.py
@@ -91,6 +91,22 @@ class TestCronAddTool:
         assert result.is_error
         assert "channel is required" in result.content
 
+    async def test_add_rejects_non_positive_interval(self, tmp_path: Path) -> None:
+        storage = _storage(tmp_path)
+        tool = CronAddTool(
+            storage=storage, default_channel="email:user@example.com", default_metadata={}
+        )
+
+        result = await tool.execute(name="Invalid", message="Ping", schedule="every 0")
+
+        assert result.is_error
+        assert "Invalid schedule" in result.content
+
+        negative_result = await tool.execute(name="Invalid", message="Ping", schedule="every -1")
+
+        assert negative_result.is_error
+        assert "Invalid schedule" in negative_result.content
+
 
 class TestCronListRemoveSetEnabled:
     async def test_list_remove_and_toggle(self, tmp_path: Path) -> None:

--- a/tests/core/test_cron_ops.py
+++ b/tests/core/test_cron_ops.py
@@ -50,6 +50,20 @@ def test_validate_job_returns_error_for_invalid_schedule() -> None:
     assert "Invalid schedule" in error
 
 
+def test_validate_job_returns_error_for_zero_interval() -> None:
+    now = datetime(2026, 2, 27, 9, 0, tzinfo=UTC)
+    error = validate_job(_job(schedule="every 0"), now=now)
+    assert error is not None
+    assert "Invalid schedule" in error
+
+
+def test_validate_job_returns_error_for_negative_interval() -> None:
+    now = datetime(2026, 2, 27, 9, 0, tzinfo=UTC)
+    error = validate_job(_job(schedule="every -1"), now=now)
+    assert error is not None
+    assert "Invalid schedule" in error
+
+
 def test_add_job_appends_valid_job() -> None:
     existing = [_job(id="existing")]
     new_job = _job(id="new", schedule="every 60")

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -21,6 +21,24 @@ def test_parse_interval():
     assert next_run is not None
 
 
+def test_parse_interval_zero_is_invalid() -> None:
+    job = CronJob(id="1", name="test", message="hi", schedule="every 0", channel="cli:local")
+    next_run = parse_schedule(job, now=datetime(2026, 2, 21, 8, 0, tzinfo=UTC))
+    assert next_run is None
+
+
+def test_parse_interval_negative_is_invalid() -> None:
+    job = CronJob(id="1", name="test", message="hi", schedule="every -1", channel="cli:local")
+    next_run = parse_schedule(job, now=datetime(2026, 2, 21, 8, 0, tzinfo=UTC))
+    assert next_run is None
+
+
+def test_parse_interval_one_second_is_valid() -> None:
+    job = CronJob(id="1", name="test", message="hi", schedule="every 1", channel="cli:local")
+    next_run = parse_schedule(job, now=datetime(2026, 2, 21, 8, 0, tzinfo=UTC))
+    assert next_run is not None
+
+
 def test_is_due_past_time():
     job = CronJob(
         id="1",
@@ -37,6 +55,32 @@ def test_is_due_past_time():
 def test_is_not_due_before_time():
     job = CronJob(id="1", name="test", message="hi", schedule="0 9 * * *", channel="cli:local")
     now = datetime(2026, 2, 21, 8, 59, tzinfo=UTC)
+    assert not is_due(job, now=now)
+
+
+def test_is_not_due_for_zero_interval() -> None:
+    now = datetime(2026, 2, 21, 8, 59, tzinfo=UTC)
+    job = CronJob(
+        id="1",
+        name="test",
+        message="hi",
+        schedule="every 0",
+        channel="cli:local",
+        last_run=now,
+    )
+    assert not is_due(job, now=now)
+
+
+def test_is_not_due_for_negative_interval() -> None:
+    now = datetime(2026, 2, 21, 8, 59, tzinfo=UTC)
+    job = CronJob(
+        id="1",
+        name="test",
+        message="hi",
+        schedule="every -1",
+        channel="cli:local",
+        last_run=now,
+    )
     assert not is_due(job, now=now)
 
 


### PR DESCRIPTION
## Summary
- reject `every N` schedules when `N <= 0` in `parse_schedule` so invalid intervals cannot be created
- harden `is_due` to return `False` for non-positive intervals to safely handle legacy or manually edited jobs
- add scheduler, cron_ops, and cron tool tests covering `every 0` and negative intervals

## Verification
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run mypy squidbot/`
- `uv run pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Schedule validation now rejects non-positive interval values (zero and negative).
  * Interval-based scheduling prevents execution with invalid intervals.

* **Tests**
  * Added comprehensive test coverage for schedule interval validation edge cases and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->