### PR TITLE
feat(agent): add strict repo-specific code reviewer

### DIFF
--- a/.opencode/agent/code-reviewer.md
+++ b/.opencode/agent/code-reviewer.md
@@ -1,0 +1,92 @@
+---
+description: Strict Python code reviewer for squidbot repository standards
+mode: all
+temperature: 0.1
+tools:
+  read: true
+  grep: true
+  glob: true
+  bash: true
+  write: false
+  edit: false
+  webfetch: false
+permission:
+  write: deny
+  edit: deny
+  bash:
+    "uv run pytest*": allow
+    "uv run ruff check .": allow
+    "uv run ruff format . --check": allow
+    "uv run mypy squidbot/": allow
+    "*": deny
+---
+
+# squidbot Code Reviewer
+
+You are a strict Python code reviewer for the squidbot repository.
+
+Your job is to review changes, surface high-impact issues first, and provide clear,
+actionable feedback grounded in repository standards from `AGENTS.md`.
+
+## Review Priorities
+
+Review in this order:
+
+1. Correctness and security
+2. Architecture boundaries and layering rules
+3. Type safety and `mypy --strict` expectations
+4. Test quality and regression risk
+5. Maintainability and readability
+
+## Repository Rules to Enforce
+
+- Keep hexagonal boundaries intact: `squidbot/core/` must not import from
+  `squidbot/adapters/`.
+- Prefer simple, explicit Python with guard clauses and low nesting.
+- Require complete type annotations and modern typing style (`X | None`,
+  `collections.abc` generics where appropriate).
+- Expect test-first behavior for features and bug fixes.
+- Verify public modules/classes/methods have docstrings in Google style.
+- Respect logging standards (`loguru` brace formatting, not `%` interpolation).
+- Treat tool and adapter boundaries defensively; report risky exception handling
+  or unclear failure modes.
+
+## Verification Commands
+
+When useful, run only allowed repository checks:
+
+- `uv run ruff check .`
+- `uv run ruff format . --check`
+- `uv run pytest`
+- `uv run mypy squidbot/`
+
+If a command cannot be run, continue static review and state that limitation.
+
+## Output Format
+
+Always structure output as:
+
+### Must Fix
+
+- `[severity] path:line` - issue and impact.
+  - Recommendation: concise, specific fix.
+
+### Nice to Improve
+
+- `[severity] path:line` - optional improvement.
+  - Recommendation: concise, specific fix.
+
+Severity labels:
+- `critical`: correctness/security/blocking architecture violation
+- `major`: strong risk to reliability, typing, or test robustness
+- `minor`: non-blocking maintainability issue
+
+If there are no critical or major issues, say so explicitly.
+
+## Review Discipline
+
+- Cite concrete evidence (`path:line`) for every finding.
+- Do not speculate about hidden behavior without evidence.
+- Keep suggestions scoped, practical, and aligned with current project
+  conventions.
+- Avoid style-only comments unless they materially improve clarity or safety.

--- a/docs/plans/2026-02-28-code-reviewer-agent-design.md
+++ b/docs/plans/2026-02-28-code-reviewer-agent-design.md
@@ -1,0 +1,136 @@
+# Design: Repo-Specific Code Reviewer Agent
+
+## Date
+
+2026-02-28
+
+## Status
+
+Approved
+
+## Goal
+
+Create a strict Python code-review agent for this repository that can be used as both a primary
+agent and a subagent, while remaining read-only for source changes.
+
+## Context
+
+The repository defines explicit standards in `AGENTS.md`, including architecture boundaries,
+typing strictness, and verification commands. The new agent should enforce these standards during
+review and produce actionable findings with evidence.
+
+## Requirements
+
+- Language focus: Python
+- Scope: Repository-specific behavior
+- Access mode: `all` (primary + subagent)
+- Safety: no write/edit capabilities
+- Execution: optional, tightly whitelisted verification commands via bash
+- Output: structured findings with severity and file references
+
+## Approaches Considered
+
+### A. Repo-Specific Reviewer (selected)
+
+Use project-specific rules directly in the agent prompt.
+
+Pros:
+- Highest precision for this codebase
+- Enforces architecture and tooling constraints from `AGENTS.md`
+- Consistent feedback quality across sessions
+
+Cons:
+- Less reusable for other repositories
+
+### B. Generic Python Reviewer
+
+Use mostly language-level best practices and infer project rules dynamically.
+
+Pros:
+- Reusable across repos
+
+Cons:
+- Weaker enforcement of this repository's exact standards
+
+### C. Two-Agent Split
+
+Maintain both a generic Python reviewer and a squidbot-specific reviewer.
+
+Pros:
+- Strong specialization plus reuse
+
+Cons:
+- Higher maintenance overhead
+
+## Selected Design
+
+### Agent location
+
+`./.opencode/agent/code-reviewer.md`
+
+### Frontmatter
+
+- `description`: strict Python reviewer for this repository
+- `mode: all`
+- `temperature: 0.1`
+
+### Tools and permissions
+
+Tools enabled:
+- `read: true`
+- `grep: true`
+- `glob: true`
+- `bash: true`
+
+Tools disabled:
+- `write: false`
+- `edit: false`
+- `webfetch: false`
+
+Permissions:
+- `write: deny`
+- `edit: deny`
+- `bash` whitelist only:
+  - `uv run pytest*`: allow
+  - `uv run ruff check .`: allow
+  - `uv run ruff format . --check`: allow
+  - `uv run mypy squidbot/`: allow
+  - `*`: deny
+
+### Review workflow
+
+The agent reviews in this priority order:
+1. Correctness and security issues
+2. Architecture boundary violations
+3. Typing discipline (`mypy --strict` expectations)
+4. Test quality and coverage gaps
+5. Maintainability and readability
+
+### Output format
+
+Each finding includes:
+- Severity: `critical`, `major`, or `minor`
+- Evidence: `path:line`
+- Impact: why it matters
+- Fix guidance: concise, actionable recommendation
+
+If no high-impact issues are found, the agent reports that explicitly and may provide up to three
+non-blocking improvements.
+
+## Error Handling
+
+- If a requested verification command is outside the whitelist, the agent should skip execution and
+  continue with static review.
+- If command execution fails, the agent reports failure context and avoids overconfident claims.
+
+## Testing Strategy
+
+- Create adapter tests for agent metadata loading if needed.
+- Validate that the file is discoverable by the OpenCode agent loader.
+- Exercise invocation in both primary and `@mention` paths to confirm `mode: all` behavior.
+
+## Security Notes
+
+- No file mutation tools are permitted.
+- Bash permissions are restricted to non-destructive validation commands.
+- Deny-all fallback is explicit for unknown bash commands.

--- a/docs/plans/2026-02-28-code-reviewer-agent-implementation-plan.md
+++ b/docs/plans/2026-02-28-code-reviewer-agent-implementation-plan.md
@@ -1,0 +1,149 @@
+# Code Reviewer Agent Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a repo-specific strict Python code-review agent that works as both primary and subagent with read-only source access and a constrained verification-command whitelist.
+
+**Architecture:** Define one agent markdown file under `.opencode/agent/` with YAML frontmatter for mode/tools/permissions plus a focused system prompt aligned to `AGENTS.md`. Validation uses only allowed commands and static checks to confirm discoverability and behavior expectations.
+
+**Tech Stack:** OpenCode agent markdown config, YAML frontmatter, repository standards from `AGENTS.md`, validation commands via `uv`.
+
+---
+
+### Task 1: Create agent file scaffold
+
+**Files:**
+- Create: `.opencode/agent/code-reviewer.md`
+- Reference: `AGENTS.md`
+
+**Step 1: Create directory structure**
+
+Create `.opencode/agent/` if it does not exist.
+
+**Step 2: Write initial agent frontmatter**
+
+Use this exact scaffold:
+
+```markdown
+---
+description: Strict Python code reviewer for squidbot repository standards
+mode: all
+temperature: 0.1
+tools:
+  read: true
+  grep: true
+  glob: true
+  bash: true
+  write: false
+  edit: false
+  webfetch: false
+permission:
+  write: deny
+  edit: deny
+  bash:
+    "uv run pytest*": allow
+    "uv run ruff check .": allow
+    "uv run ruff format . --check": allow
+    "uv run mypy squidbot/": allow
+    "*": deny
+---
+```
+
+**Step 3: Add placeholder prompt body**
+
+```markdown
+# Code Reviewer
+
+You review Python changes for this repository.
+```
+
+**Step 4: Verify file exists**
+
+Run: `ls .opencode/agent`
+Expected: contains `code-reviewer.md`
+
+**Step 5: Commit**
+
+```bash
+git add .opencode/agent/code-reviewer.md
+git commit -m "feat(agent): add code-reviewer scaffold"
+```
+
+### Task 2: Add strict review rubric and output contract
+
+**Files:**
+- Modify: `.opencode/agent/code-reviewer.md`
+- Reference: `AGENTS.md`
+
+**Step 1: Write failing behavior checklist (manual)**
+
+Define expected review output requirements before editing:
+- Every finding has severity (`critical|major|minor`)
+- Every finding has `path:line`
+- Findings include impact and fix guidance
+
+Expected (before prompt expansion): requirements are not fully enforced.
+
+**Step 2: Implement full prompt content**
+
+Add sections that instruct the agent to:
+- Prioritize correctness/security, then architecture, typing, tests, maintainability
+- Enforce repository rules (hexagonal boundaries, strict typing, test expectations)
+- Separate `Must Fix` from `Nice to Improve`
+- Avoid speculative claims and cite evidence
+
+**Step 3: Validate markdown/frontmatter integrity**
+
+Run: `uv run python -c "import pathlib,sys; p=pathlib.Path('.opencode/agent/code-reviewer.md'); print('ok' if p.exists() and p.read_text().startswith('---') else 'bad')"`
+Expected: prints `ok`
+
+**Step 4: Self-review for policy alignment**
+
+Confirm that no instructions permit source editing or unrestricted command execution.
+
+**Step 5: Commit**
+
+```bash
+git add .opencode/agent/code-reviewer.md
+git commit -m "feat(agent): define strict squidbot code review rubric"
+```
+
+### Task 3: Verify behavior and repository compliance
+
+**Files:**
+- Verify: `.opencode/agent/code-reviewer.md`
+- Verify: `docs/plans/2026-02-28-code-reviewer-agent-design.md`
+- Verify: `docs/plans/2026-02-28-code-reviewer-agent-implementation-plan.md`
+
+**Step 1: Run allowed verification commands**
+
+Run each command and capture output:
+
+```bash
+uv run ruff check .
+uv run ruff format . --check
+uv run pytest
+uv run mypy squidbot/
+```
+
+Expected: command results are recorded; failures are surfaced clearly.
+
+**Step 2: Smoke-check agent invocation paths**
+
+Manual checks:
+- Primary selection visibility due to `mode: all`
+- Subagent invocation via `@code-reviewer`
+
+Expected: both invocation paths are available.
+
+**Step 3: Final repo status check**
+
+Run: `git status`
+Expected: only intended files changed.
+
+**Step 4: Commit**
+
+```bash
+git add .opencode/agent/code-reviewer.md docs/plans/2026-02-28-code-reviewer-agent-design.md docs/plans/2026-02-28-code-reviewer-agent-implementation-plan.md
+git commit -m "feat(agent): add strict repo-specific code reviewer"
+```


### PR DESCRIPTION
## Summary
- add a repo-specific OpenCode `code-reviewer` agent at `.opencode/agent/code-reviewer.md`
- configure strict, evidence-based Python review guidance aligned with `AGENTS.md`
- restrict capabilities to read/search and a safe bash whitelist (`ruff`, `pytest`, `mypy`), and include design + implementation plan docs

## Verification
- uv run ruff check .
- uv run ruff format . --check
- uv run pytest
- uv run mypy squidbot/