### PR TITLE
feat(matrix): handle encrypted inbound file attachments

### DIFF
--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md
@@ -37,17 +37,61 @@ Route both through one shared media processing path.
 
 Normalize extraction order:
 
-- URL: `event.url` -> `event.file.url` -> `event.source["content"]["file"]["url"]`
-- MIME: `info.mimetype` fallback
-- Filename: `event.body` fallback
-- Encryption material:
-  - direct attrs: `event.key`, `event.hashes`, `event.iv`
-  - nested dict: `content.file.key`, `content.file.hashes`, `content.file.iv`
+**URL (three-level fallback):**
+
+1. `event.url` — direct attribute on the event
+2. `event.file.url` — nested `file` object attribute
+3. `event.source.get("content", {}).get("file", {}).get("url", "")` — raw source dict; this
+   is the shape produced by some clients for encrypted `m.file` events where `event.url` is
+   empty string and `event.file` is `None`
+
+Implement as `_extract_media_url(event: Any) -> str`:
+
+```python
+def _extract_media_url(event: Any) -> str:
+    """Return the first non-empty mxc:// URL from event using three-level fallback."""
+    return (
+        getattr(event, "url", "") or
+        getattr(getattr(event, "file", None), "url", "") or
+        event.source.get("content", {}).get("file", {}).get("url", "") or
+        ""
+    )
+```
+
+**MIME:** `info.mimetype` fallback
+
+**Filename:** `event.body` fallback
+
+**Encryption material (two-form fallback):**
+
+- Direct attrs: `event.key`, `event.hashes`, `event.iv`
+- Nested dict: `event.source.get("content", {}).get("file", {})` — extract `key`, `hashes`,
+  `iv` from this dict when direct attrs are absent (covers the case where `event.file is None`
+  but key material is present in the raw source)
+
+When decrypting, prefer direct attrs; fall back to the nested dict. Both paths must be covered
+by tests.
 
 ### Mention Policy Safety
 
-Do not drop media events only because filename/body lacks textual mention markers in
-`group_policy="mention"` rooms.
+In `group_policy = "mention"` rooms, `_accept_event` checks `event.body` for the bot's name.
+For media events `body` is the filename (e.g. `photo.jpg`), which never contains a mention —
+causing silent drops.
+
+**Fix:** In `_accept_event`, before the body-based mention check, detect whether the event is
+a media event by inspecting `msgtype`:
+
+```python
+MEDIA_MSGTYPES = {"m.image", "m.file", "m.audio", "m.video"}
+
+msgtype = event.source.get("content", {}).get("msgtype", "")
+if msgtype in MEDIA_MSGTYPES:
+    return True  # skip mention check for all media uploads
+```
+
+This applies to all media msgtypes (`m.image`, `m.file`, `m.audio`, `m.video`) — media uploads
+in mention-policy rooms are always accepted regardless of the filename. Text events (`m.text`,
+`m.notice`, `m.emote`) continue to require a textual mention.
 
 ### Conditional BadEvent Fallback
 
@@ -56,35 +100,49 @@ Default behavior: no fallback.
 If diagnostics show encrypted uploads arrive as non-media parser class and bypass callbacks,
 add a guarded fallback path that only accepts media-shaped payloads.
 
+**Observable trigger criterion:** After deploying dual-callback registration (Task 3), send an
+encrypted file from a Matrix client. Run with `LOG_LEVEL=DEBUG`. Search logs for
+`MatrixChannel: _handle_media`. If no such line appears for the upload event, the fallback is
+needed. If `_handle_media` is called, mark Task 5 as skipped.
+
 ## Debug Diagnostics
 
-Add `logger.debug(...)` for:
+Add `logger.debug(...)` at five boundaries. Log format (exact strings, greppable):
 
-1. Callback registration summary.
-2. Event classification: `event_class`, `msgtype`, `has_url`, `has_file_url`, `has_key_material`.
-3. Policy decision with reason codes (`accepted`, `policy_filtered`, `missing_media_url`, etc.).
-4. Download/decrypt branch and failure reasons.
-5. Embed decision (`embedded` vs fallback + reason).
+| Boundary | Log format |
+|----------|------------|
+| Callback registration | `"MatrixChannel: registered callbacks classes={}"` |
+| Event classification | `"MatrixChannel: classify event={} class={} msgtype={} has_url={} has_file_url={} has_key_material={}"` |
+| Policy decision | `"MatrixChannel: policy event={} result={} reason={}"` |
+| Download/decrypt branch | `"MatrixChannel: download event={} encrypted={} url={}"` |
+| Embed decision | `"MatrixChannel: embed mxc={} embedded={} reason={}"` |
 
-Reason codes must be deterministic and greppable.
+Reason codes must be deterministic and greppable: `accepted`, `policy_filtered`,
+`missing_media_url`, `decryption_failed`, `size_exceeded`, `embedded`, `not_embedded`.
 
 ## Testing Strategy
 
 Primary tests in `tests/adapters/channels/test_matrix.py`:
 
-- callback registration includes both media classes
-- encrypted `m.file` with `content.file.url` is processed
-- decryption works with direct-attr and nested-file key-material forms
-- mention-policy media acceptance is correct
-- diagnostics emit expected reason codes
+- Callback registration includes both media classes; `RoomEncryptedMedia` is registered
+  specifically with `_handle_media` (not another handler)
+- Encrypted `m.file` with `content.file.url` (and `event.file=None`, `event.url=""`) is
+  processed — URL extracted from third fallback path
+- Decryption with direct-attr key material (`event.key`, `event.hashes`, `event.iv`)
+- Decryption with nested key material from `source["content"]["file"]["key/hashes/iv"]`
+  when `event.file is None`
+- Mention-policy: all media msgtypes are accepted without a textual mention marker
+- Diagnostics emit expected reason codes (greppable format)
+- Malformed `declared_size` (non-integer `size` field): download still attempted; document
+  that preflight guard is bypassed gracefully and post-fetch guard applies
 
-Conditional tests (only if fallback enabled):
+Conditional tests (only if fallback enabled — Task 5):
 
-- media-shaped `BadEvent` routes into media pipeline
-- non-media `BadEvent` remains ignored
+- Media-shaped `BadEvent` routes into media pipeline
+- Non-media `BadEvent` remains ignored
 
 ## Risks
 
 - Over-accepting malformed events -> mitigate with strict media-shape checks.
 - Debug noise -> debug-level only.
-- Mention-policy regression -> explicit policy regression tests.
+- Mention-policy regression -> explicit policy regression tests covering all four media msgtypes.

--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md
@@ -1,0 +1,90 @@
+# Matrix Encrypted Media Intake Design
+
+## Context
+
+The previous Matrix attachment work fixed outbound uploads and basic inbound media handling.
+We now have a production issue where user-uploaded encrypted `m.file` payloads are sometimes
+not visible to the agent.
+
+Observed shape includes `content.file.url` + encryption metadata (`key`, `hashes`, `iv`).
+
+## Goals
+
+1. Ensure inbound media intake handles both `RoomMessageMedia` and `RoomEncryptedMedia`.
+2. Add debug diagnostics for event classification and routing decisions.
+3. Normalize encrypted media extraction so different payload shapes are handled consistently.
+4. Preserve existing size guardrails and embedding rules.
+5. Add `BadEvent` fallback only if diagnostics prove media callbacks still miss events.
+
+## Non-Goals
+
+- Outbound media redesign.
+- OCR/transcription.
+- Cross-channel changes outside Matrix.
+
+## Architecture
+
+### Dual Media Callback Handling
+
+Register inbound callbacks for:
+
+- `RoomMessageMedia`
+- `RoomEncryptedMedia`
+
+Route both through one shared media processing path.
+
+### Normalized Media Descriptor
+
+Normalize extraction order:
+
+- URL: `event.url` -> `event.file.url` -> `event.source["content"]["file"]["url"]`
+- MIME: `info.mimetype` fallback
+- Filename: `event.body` fallback
+- Encryption material:
+  - direct attrs: `event.key`, `event.hashes`, `event.iv`
+  - nested dict: `content.file.key`, `content.file.hashes`, `content.file.iv`
+
+### Mention Policy Safety
+
+Do not drop media events only because filename/body lacks textual mention markers in
+`group_policy="mention"` rooms.
+
+### Conditional BadEvent Fallback
+
+Default behavior: no fallback.
+
+If diagnostics show encrypted uploads arrive as non-media parser class and bypass callbacks,
+add a guarded fallback path that only accepts media-shaped payloads.
+
+## Debug Diagnostics
+
+Add `logger.debug(...)` for:
+
+1. Callback registration summary.
+2. Event classification: `event_class`, `msgtype`, `has_url`, `has_file_url`, `has_key_material`.
+3. Policy decision with reason codes (`accepted`, `policy_filtered`, `missing_media_url`, etc.).
+4. Download/decrypt branch and failure reasons.
+5. Embed decision (`embedded` vs fallback + reason).
+
+Reason codes must be deterministic and greppable.
+
+## Testing Strategy
+
+Primary tests in `tests/adapters/channels/test_matrix.py`:
+
+- callback registration includes both media classes
+- encrypted `m.file` with `content.file.url` is processed
+- decryption works with direct-attr and nested-file key-material forms
+- mention-policy media acceptance is correct
+- diagnostics emit expected reason codes
+
+Conditional tests (only if fallback enabled):
+
+- media-shaped `BadEvent` routes into media pipeline
+- non-media `BadEvent` remains ignored
+
+## Risks
+
+- Over-accepting malformed events -> mitigate with strict media-shape checks.
+- Debug noise -> debug-level only.
+- Mention-policy regression -> explicit policy regression tests.

--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md
@@ -3,18 +3,47 @@
 ## Context
 
 The previous Matrix attachment work fixed outbound uploads and basic inbound media handling.
-We now have a production issue where user-uploaded encrypted `m.file` payloads are sometimes
-not visible to the agent.
+We now have a production issue where user-uploaded encrypted `m.file` payloads are not
+visible to the agent.
 
-Observed shape includes `content.file.url` + encryption metadata (`key`, `hashes`, `iv`).
+## Root Cause
+
+Two separate failure modes, depending on room configuration:
+
+**Case A — E2EE room (`e2ee_enabled=True`):** The bot has Megolm session keys. nio decrypts
+`m.room.encrypted` wrappers via `parse_decrypted_event`, producing `RoomEncryptedFile` /
+`RoomEncryptedImage` / `RoomEncryptedAudio` / `RoomEncryptedVideo` — all subclasses of
+`RoomEncryptedMedia`. These events are **never registered** with an inbound callback in the
+current squidbot implementation.
+
+**Case B — Non-E2EE room (or client sending unencrypted `m.room.message` with
+`content.file`):** The client omits `content.url` and puts the URL inside `content.file.url`.
+nio's schema validator requires `content.url` for `m.room.message` media events and fails
+validation → returns `BadEvent`. The existing `RoomMessageMedia` callback never fires.
+
+## Event-Shape Taxonomy
+
+Three distinct shapes arrive at the Matrix adapter (verified against nio source):
+
+| Shape | nio type | `event.url` | Key-material attrs | When |
+|---|---|---|---|---|
+| Unencrypted file (`content.url`) | `RoomMessageFile` / `RoomMessageImage` / … | direct attr | — | Non-E2EE room, unencrypted upload |
+| E2EE-decrypted file (Megolm) | `RoomEncryptedFile` / … (`RoomEncryptedMedia` subclass) | direct attr | `event.key` (dict), `event.iv` (str), `event.hashes` (dict) — all direct attrs | E2EE room, bot has session keys |
+| Encrypted-metadata file without E2EE | `BadEvent` | absent | absent — in `source['content']['file']` | Non-E2EE room, client uses `content.file` shape |
+
+nio's `add_event_callback` accepts a tuple of types: registering
+`(RoomMessageMedia, RoomEncryptedMedia)` handles Cases A + unencrypted. Case B requires a
+separate `BadEvent` callback.
 
 ## Goals
 
-1. Ensure inbound media intake handles both `RoomMessageMedia` and `RoomEncryptedMedia`.
-2. Add debug diagnostics for event classification and routing decisions.
-3. Normalize encrypted media extraction so different payload shapes are handled consistently.
-4. Preserve existing size guardrails and embedding rules.
-5. Add `BadEvent` fallback only if diagnostics prove media callbacks still miss events.
+1. Register `RoomEncryptedMedia` callback (fix Case A — E2EE rooms).
+2. Add `BadEvent` fallback for media-shaped bad events (fix Case B).
+3. Fix pre-existing `decrypt_attachment` call-site bug: dict arg → correct positional string
+   args extracted from `event.key["k"]`, `event.hashes["sha256"]`, `event.iv`.
+4. Add debug diagnostics for event classification and routing decisions.
+5. Preserve existing size guardrails and embedding rules.
+6. Preserve mention-policy safety for media events.
 
 ## Non-Goals
 
@@ -24,62 +53,77 @@ Observed shape includes `content.file.url` + encryption metadata (`key`, `hashes
 
 ## Architecture
 
-### Dual Media Callback Handling
+### Dual Callback Registration
 
-Register inbound callbacks for:
-
-- `RoomMessageMedia`
-- `RoomEncryptedMedia`
-
-Route both through one shared media processing path.
-
-### Normalized Media Descriptor
-
-Normalize extraction order:
-
-**URL (three-level fallback):**
-
-1. `event.url` — direct attribute on the event
-2. `event.file.url` — nested `file` object attribute
-3. `event.source.get("content", {}).get("file", {}).get("url", "")` — raw source dict; this
-   is the shape produced by some clients for encrypted `m.file` events where `event.url` is
-   empty string and `event.file` is `None`
-
-Implement as `_extract_media_url(event: Any) -> str`:
+Register one callback covering both unencrypted and E2EE-decrypted events:
 
 ```python
-def _extract_media_url(event: Any) -> str:
-    """Return the first non-empty mxc:// URL from event using three-level fallback."""
-    return (
-        getattr(event, "url", "") or
-        getattr(getattr(event, "file", None), "url", "") or
-        event.source.get("content", {}).get("file", {}).get("url", "") or
-        ""
-    )
+MEDIA_EVENT_FILTER = (RoomMessageMedia, RoomEncryptedMedia)
+client.add_event_callback(self._handle_media, MEDIA_EVENT_FILTER)
 ```
 
-**MIME:** `info.mimetype` fallback
+Register a separate callback for the `BadEvent` fallback:
 
-**Filename:** `event.body` fallback
+```python
+client.add_event_callback(self._handle_bad_event, nio.BadEvent)
+```
 
-**Encryption material (two-form fallback):**
+### BadEvent Fallback
 
-- Direct attrs: `event.key`, `event.hashes`, `event.iv`
-- Nested dict: `event.source.get("content", {}).get("file", {})` — extract `key`, `hashes`,
-  `iv` from this dict when direct attrs are absent (covers the case where `event.file is None`
-  but key material is present in the raw source)
+In `_handle_bad_event`, apply a strict media-shape guard before routing:
 
-When decrypting, prefer direct attrs; fall back to the nested dict. Both paths must be covered
-by tests.
+```python
+MEDIA_MSGTYPES = {"m.image", "m.file", "m.audio", "m.video"}
+
+def _is_media_shaped_bad_event(event: nio.BadEvent) -> bool:
+    content = event.source.get("content", {})
+    msgtype = content.get("msgtype", "")
+    has_file_url = bool(content.get("file", {}).get("url", ""))
+    return msgtype in MEDIA_MSGTYPES and has_file_url
+```
+
+Non-media bad events are ignored as before.
+
+For `BadEvent`, URL and key material come from `source["content"]["file"]`:
+
+```python
+content_file = event.source["content"]["file"]
+mxc_url = content_file["url"]
+# Decrypt:
+body = decrypt_attachment(
+    body,
+    content_file["key"]["k"],
+    content_file["hashes"]["sha256"],
+    content_file["iv"],
+)
+```
+
+### Fix `decrypt_attachment` Call (Pre-existing Bug)
+
+The existing code at `matrix.py:773` calls `decrypt_attachment_fn(body, key_info)` passing a
+dict. The correct signature is `decrypt_attachment(ciphertext, key, hash, iv)` with four
+positional string args.
+
+For `RoomEncryptedMedia` events (direct attrs):
+
+```python
+body = decrypt_attachment(
+    body,
+    event.key["k"],
+    event.hashes["sha256"],
+    event.iv,
+)
+```
+
+Both call sites must be covered by tests that verify actual argument shapes.
 
 ### Mention Policy Safety
 
 In `group_policy = "mention"` rooms, `_accept_event` checks `event.body` for the bot's name.
-For media events `body` is the filename (e.g. `photo.jpg`), which never contains a mention —
-causing silent drops.
+For media events `body` is the filename, which never contains a mention.
 
-**Fix:** In `_accept_event`, before the body-based mention check, detect whether the event is
-a media event by inspecting `msgtype`:
+**Fix:** In `_accept_event`, before the body-based mention check, detect media events via
+`msgtype`:
 
 ```python
 MEDIA_MSGTYPES = {"m.image", "m.file", "m.audio", "m.video"}
@@ -89,60 +133,48 @@ if msgtype in MEDIA_MSGTYPES:
     return True  # skip mention check for all media uploads
 ```
 
-This applies to all media msgtypes (`m.image`, `m.file`, `m.audio`, `m.video`) — media uploads
-in mention-policy rooms are always accepted regardless of the filename. Text events (`m.text`,
-`m.notice`, `m.emote`) continue to require a textual mention.
+Applies to all four media msgtypes. Text events (`m.text`, `m.notice`, `m.emote`) continue
+to require a textual mention.
 
-### Conditional BadEvent Fallback
-
-Default behavior: no fallback.
-
-If diagnostics show encrypted uploads arrive as non-media parser class and bypass callbacks,
-add a guarded fallback path that only accepts media-shaped payloads.
-
-**Observable trigger criterion:** After deploying dual-callback registration (Task 3), send an
-encrypted file from a Matrix client. Run with `LOG_LEVEL=DEBUG`. Search logs for
-`MatrixChannel: _handle_media`. If no such line appears for the upload event, the fallback is
-needed. If `_handle_media` is called, mark Task 5 as skipped.
+> **Note for squidbot:** The nanobot-redux implementation uses
+> `_is_bot_mentioned_from_mx_mentions` which reads `m.mentions.user_ids` from the source
+> dict — this avoids the body/filename confusion entirely. That is the cleaner long-term fix,
+> but is out of scope for this feature.
 
 ## Debug Diagnostics
 
 Add `logger.debug(...)` at five boundaries. Log format (exact strings, greppable):
 
 | Boundary | Log format |
-|----------|------------|
+|---|---|
 | Callback registration | `"MatrixChannel: registered callbacks classes={}"` |
 | Event classification | `"MatrixChannel: classify event={} class={} msgtype={} has_url={} has_file_url={} has_key_material={}"` |
 | Policy decision | `"MatrixChannel: policy event={} result={} reason={}"` |
 | Download/decrypt branch | `"MatrixChannel: download event={} encrypted={} url={}"` |
 | Embed decision | `"MatrixChannel: embed mxc={} embedded={} reason={}"` |
 
-Reason codes must be deterministic and greppable: `accepted`, `policy_filtered`,
-`missing_media_url`, `decryption_failed`, `size_exceeded`, `embedded`, `not_embedded`.
+Reason codes: `accepted`, `policy_filtered`, `missing_media_url`, `decryption_failed`,
+`size_exceeded`, `embedded`, `not_embedded`.
 
 ## Testing Strategy
 
 Primary tests in `tests/adapters/channels/test_matrix.py`:
 
-- Callback registration includes both media classes; `RoomEncryptedMedia` is registered
-  specifically with `_handle_media` (not another handler)
-- Encrypted `m.file` with `content.file.url` (and `event.file=None`, `event.url=""`) is
-  processed — URL extracted from third fallback path
-- Decryption with direct-attr key material (`event.key`, `event.hashes`, `event.iv`)
-- Decryption with nested key material from `source["content"]["file"]["key/hashes/iv"]`
-  when `event.file is None`
-- Mention-policy: all media msgtypes are accepted without a textual mention marker
-- Diagnostics emit expected reason codes (greppable format)
-- Malformed `declared_size` (non-integer `size` field): download still attempted; document
-  that preflight guard is bypassed gracefully and post-fetch guard applies
-
-Conditional tests (only if fallback enabled — Task 5):
-
-- Media-shaped `BadEvent` routes into media pipeline
-- Non-media `BadEvent` remains ignored
+- `(RoomMessageMedia, RoomEncryptedMedia)` tuple is registered with `_handle_media`
+- `BadEvent` callback is registered with `_handle_bad_event`
+- `BadEvent` with `m.file` + `content.file.url` routes into media pipeline
+- Non-media `BadEvent` is ignored
+- `RoomEncryptedFile` event: `decrypt_attachment` called with `event.key["k"]`,
+  `event.hashes["sha256"]`, `event.iv` (positional strings — not a dict)
+- `BadEvent` encrypted file: `decrypt_attachment` called with key material from
+  `source["content"]["file"]`
+- Mention-policy: all four media msgtypes accepted without textual mention marker
+- Diagnostics emit expected reason codes
+- Malformed `declared_size` (non-integer): download still attempted; post-fetch guard applies
 
 ## Risks
 
-- Over-accepting malformed events -> mitigate with strict media-shape checks.
-- Debug noise -> debug-level only.
-- Mention-policy regression -> explicit policy regression tests covering all four media msgtypes.
+- BadEvent over-acceptance: mitigated by `_is_media_shaped_bad_event` strict shape check.
+- Debug noise: debug-level only.
+- Mention-policy regression: explicit regression tests for all four media msgtypes.
+- Decrypt call signature change: covered by decrypt tests verifying positional string args.

--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
@@ -20,31 +20,67 @@ callback miss.
 
 **Step 1: Write failing callback coverage test**
 
+Assert both that `nio.RoomEncryptedMedia` is registered AND that it is registered with
+`_handle_media` specifically (not another handler):
+
 ```python
 async def test_registers_room_message_and_room_encrypted_media_callbacks() -> None:
+    # assert nio.RoomEncryptedMedia in registered_types
+    # assert any(
+    #     c.args == (ch._handle_media, nio.RoomEncryptedMedia)
+    #     for c in fake_client.add_event_callback.call_args_list
+    # ), "RoomEncryptedMedia must be registered with _handle_media, not another handler"
     ...
 ```
 
-**Step 2: Write failing encrypted payload test**
+**Step 2: Write failing encrypted payload test (third URL fallback)**
+
+This tests the shape where `event.url = ""`, `event.file = None`, but
+`source["content"]["file"]["url"]` contains the mxc URL:
 
 ```python
 async def test_encrypted_file_with_content_file_url_is_processed() -> None:
+    # event.url = "", event.file = None
+    # event.source["content"]["file"]["url"] = "mxc://..."
+    # assert download called with correct server_name and media_id
     ...
 ```
 
-**Step 3: Write failing mention-policy media test**
+**Step 3: Write failing encrypted payload test (key material from source)**
+
+Tests the case where key material (`key`, `iv`, `hashes`) is in `source["content"]["file"]`
+and `event.file is None`:
+
+```python
+async def test_encrypted_file_key_material_extracted_from_source_when_event_file_is_none() -> None:
+    # event.file = None, event.url = ""
+    # event.source["content"]["file"] = {"url": "mxc://...", "key": {...}, "iv": "...", "hashes": {...}}
+    # assert decrypt called with key material from source
+    ...
+```
+
+**Step 4: Write failing mention-policy media test**
 
 ```python
 async def test_media_event_not_dropped_only_due_to_filename_without_mention() -> None:
     ...
 ```
 
-**Step 4: Run tests to verify RED**
+**Step 5: Write test for malformed declared_size**
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file or callback or mention" -v`
+```python
+async def test_malformed_declared_size_does_not_block_download() -> None:
+    # event.info.size = "not-a-number"
+    # assert download is still attempted (post-fetch guard applies, preflight guard bypassed)
+    ...
+```
+
+**Step 6: Run tests to verify RED**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file or callback or mention or declared_size" -v`
 Expected: FAIL.
 
-**Step 5: Commit red tests**
+**Step 7: Commit red tests**
 
 ```bash
 git add tests/adapters/channels/test_matrix.py
@@ -59,8 +95,13 @@ git commit -m "test(matrix): add failing encrypted media intake coverage"
 
 **Step 1: Write failing diagnostic assertion test**
 
+Assert the exact log format strings from the design doc:
+
 ```python
 async def test_debug_logs_include_event_class_and_media_shape() -> None:
+    # capture loguru output at DEBUG level
+    # assert log contains: "MatrixChannel: classify event=... class=... msgtype=... has_url=... has_file_url=... has_key_material=..."
+    # assert log contains: "MatrixChannel: policy event=... result=... reason=..."
     ...
 ```
 
@@ -71,8 +112,18 @@ Expected: FAIL.
 
 **Step 3: Implement debug logging boundaries**
 
-Add debug logs for callback registration, event classification, policy decisions,
-download/decrypt branches, and embed decisions.
+Add `logger.debug(...)` at five boundaries using the exact log format from the design doc:
+
+| Boundary | Log format |
+|----------|------------|
+| Callback registration | `"MatrixChannel: registered callbacks classes={}"` |
+| Event classification | `"MatrixChannel: classify event={} class={} msgtype={} has_url={} has_file_url={} has_key_material={}"` |
+| Policy decision | `"MatrixChannel: policy event={} result={} reason={}"` |
+| Download/decrypt branch | `"MatrixChannel: download event={} encrypted={} url={}"` |
+| Embed decision | `"MatrixChannel: embed mxc={} embedded={} reason={}"` |
+
+Reason codes: `accepted`, `policy_filtered`, `missing_media_url`, `decryption_failed`,
+`size_exceeded`, `embedded`, `not_embedded`.
 
 **Step 4: Re-run diagnostic tests**
 
@@ -95,22 +146,46 @@ git commit -m "feat(matrix): add inbound media parser diagnostics"
 **Step 1: Register both callback classes**
 
 - `nio.RoomMessageMedia`
-- `nio.RoomEncryptedMedia`
+- `nio.RoomEncryptedMedia` — registered with `_handle_media`
 
-**Step 2: Implement normalized URL/key extraction helper**
+**Step 2: Implement `_extract_media_url` helper**
 
-Precedence:
-- URL: `event.url` -> `event.file.url` -> `event.source.content.file.url`
-- key material: direct attrs first, then nested file dict
+Three-level URL fallback with safe `.get()` access throughout:
 
-**Step 3: Route both classes through same media processing path**
+```python
+def _extract_media_url(event: Any) -> str:
+    """Return the first non-empty mxc:// URL from event using three-level fallback."""
+    return (
+        getattr(event, "url", "") or
+        getattr(getattr(event, "file", None), "url", "") or
+        event.source.get("content", {}).get("file", {}).get("url", "") or
+        ""
+    )
+```
 
-**Step 4: Run focused tests**
+**Step 3: Implement key-material extraction helper**
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file_with_content_file_url or callback" -v`
+When `event.file is None`, extract key material from `source["content"]["file"]`:
+
+```python
+def _extract_key_material(event: Any) -> tuple[dict, str, dict] | None:
+    """Return (key, iv, hashes) from event or source, or None if unavailable."""
+    if getattr(event, "key", None):
+        return event.key, event.iv, event.hashes
+    source_file = event.source.get("content", {}).get("file", {})
+    if source_file.get("key"):
+        return source_file["key"], source_file["iv"], source_file["hashes"]
+    return None
+```
+
+**Step 4: Route both classes through same media processing path**
+
+**Step 5: Run focused tests**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file or callback" -v`
 Expected: PASS.
 
-**Step 5: Commit implementation**
+**Step 6: Commit implementation**
 
 ```bash
 git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
@@ -123,10 +198,14 @@ git commit -m "fix(matrix): handle room media and encrypted media event classes"
 - Modify: `squidbot/adapters/channels/matrix.py`
 - Modify: `tests/adapters/channels/test_matrix.py`
 
-**Step 1: Write failing media policy regression test**
+**Step 1: Write failing media policy regression tests**
+
+Test all four media msgtypes:
 
 ```python
 async def test_mention_policy_accepts_media_event_without_textual_mention_marker() -> None:
+    # m.image, m.file, m.audio, m.video — all must be accepted in mention-policy rooms
+    # even when body (filename) contains no bot mention
     ...
 ```
 
@@ -135,9 +214,20 @@ async def test_mention_policy_accepts_media_event_without_textual_mention_marker
 Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy_accepts_media_event" -v`
 Expected: FAIL.
 
-**Step 3: Implement minimal policy-safe logic**
+**Step 3: Implement mention-policy fix in `_accept_event`**
 
-Do not drop media events solely due to missing textual mention marker.
+Before the body-based mention check, add:
+
+```python
+MEDIA_MSGTYPES = {"m.image", "m.file", "m.audio", "m.video"}
+
+msgtype = event.source.get("content", {}).get("msgtype", "")
+if msgtype in MEDIA_MSGTYPES:
+    return True  # skip mention check for all media uploads
+```
+
+This bypasses the mention check for all four media msgtypes. Text events (`m.text`,
+`m.notice`, `m.emote`) continue to require a textual mention.
 
 **Step 4: Re-run mention policy subset**
 
@@ -151,13 +241,22 @@ git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix
 git commit -m "fix(matrix): avoid false mention-policy drops for media events"
 ```
 
+---
+
+**Decision gate (Task 5 trigger):** After deploying Task 3 and Task 4, run
+`LOG_LEVEL=DEBUG uv run squidbot gateway` and send an encrypted file from a Matrix client.
+Search logs for `MatrixChannel: _handle_media`. If no such line appears for the upload event,
+proceed to Task 5. If `_handle_media` is called, mark Task 5 as skipped and proceed to Task 6.
+
+---
+
 ### Task 5 (Conditional): Add BadEvent fallback if diagnostics prove callback miss
 
 **Files:**
 - Modify: `squidbot/adapters/channels/matrix.py`
 - Modify: `tests/adapters/channels/test_matrix.py`
 
-**Run only when logs show encrypted media bypassing both media callbacks.**
+**Only run if the Task 5 decision gate above is triggered (no `_handle_media` log appears).**
 
 **Step 1: Add failing fallback test**
 
@@ -173,7 +272,8 @@ Expected: FAIL.
 
 **Step 3: Implement guarded fallback**
 
-Only route media-shaped bad events (`msgtype` media + `content.file.url`).
+Only route media-shaped bad events (`msgtype` in `MEDIA_MSGTYPES` + `content.file.url`
+or `content.url`).
 
 **Step 4: Re-run fallback tests**
 
@@ -217,7 +317,7 @@ Expected: PASS.
 Run: `uv run pytest`
 Expected: PASS.
 
-**Step 6: Final commit (if needed)**
+**Step 6: Final integration commit**
 
 ```bash
 git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py

--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
@@ -9,7 +9,7 @@ E2EE Megolm rooms, (B) add `BadEvent` fallback for non-E2EE clients using `conte
 Fix the pre-existing `decrypt_attachment` call-site bug (dict arg → positional string args).
 Add diagnostics. Preserve mention-policy safety.
 
-**Reference implementation:** `~/projects/nanobot-redux/nanobot/channels/matrix.py` — this has
+**Reference implementation:** `nanobot-redux` — `nanobot/channels/matrix.py` — this has
 a working dual-callback setup (`MATRIX_MEDIA_EVENT_FILTER = (RoomMessageMedia, RoomEncryptedMedia)`)
 and correct `_decrypt_media_bytes` using positional string args. Port the relevant patterns.
 

--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
@@ -1,0 +1,225 @@
+# Matrix Encrypted Media Intake Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure encrypted and unencrypted Matrix uploads are consistently surfaced to the agent.
+
+**Architecture:** Add diagnostics first, then implement dual media callback handling and
+normalized encrypted payload extraction in the Matrix adapter. Keep current guardrails,
+validate mention-policy media behavior, and add a `BadEvent` fallback only if logs prove
+callback miss.
+
+**Tech Stack:** Python 3.14, matrix-nio, Loguru, pytest, mypy --strict, ruff.
+
+---
+
+### Task 1: Add failing tests for encrypted media intake
+
+**Files:**
+- Modify: `tests/adapters/channels/test_matrix.py`
+
+**Step 1: Write failing callback coverage test**
+
+```python
+async def test_registers_room_message_and_room_encrypted_media_callbacks() -> None:
+    ...
+```
+
+**Step 2: Write failing encrypted payload test**
+
+```python
+async def test_encrypted_file_with_content_file_url_is_processed() -> None:
+    ...
+```
+
+**Step 3: Write failing mention-policy media test**
+
+```python
+async def test_media_event_not_dropped_only_due_to_filename_without_mention() -> None:
+    ...
+```
+
+**Step 4: Run tests to verify RED**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file or callback or mention" -v`
+Expected: FAIL.
+
+**Step 5: Commit red tests**
+
+```bash
+git add tests/adapters/channels/test_matrix.py
+git commit -m "test(matrix): add failing encrypted media intake coverage"
+```
+
+### Task 2: Add parser/routing diagnostics
+
+**Files:**
+- Modify: `squidbot/adapters/channels/matrix.py`
+- Modify: `tests/adapters/channels/test_matrix.py`
+
+**Step 1: Write failing diagnostic assertion test**
+
+```python
+async def test_debug_logs_include_event_class_and_media_shape() -> None:
+    ...
+```
+
+**Step 2: Run to verify RED**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "debug_logs_include_event_class" -v`
+Expected: FAIL.
+
+**Step 3: Implement debug logging boundaries**
+
+Add debug logs for callback registration, event classification, policy decisions,
+download/decrypt branches, and embed decisions.
+
+**Step 4: Re-run diagnostic tests**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "debug_logs_include_event_class" -v`
+Expected: PASS.
+
+**Step 5: Commit diagnostics**
+
+```bash
+git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
+git commit -m "feat(matrix): add inbound media parser diagnostics"
+```
+
+### Task 3: Implement dual callback handling + normalized extraction
+
+**Files:**
+- Modify: `squidbot/adapters/channels/matrix.py`
+- Modify: `tests/adapters/channels/test_matrix.py`
+
+**Step 1: Register both callback classes**
+
+- `nio.RoomMessageMedia`
+- `nio.RoomEncryptedMedia`
+
+**Step 2: Implement normalized URL/key extraction helper**
+
+Precedence:
+- URL: `event.url` -> `event.file.url` -> `event.source.content.file.url`
+- key material: direct attrs first, then nested file dict
+
+**Step 3: Route both classes through same media processing path**
+
+**Step 4: Run focused tests**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file_with_content_file_url or callback" -v`
+Expected: PASS.
+
+**Step 5: Commit implementation**
+
+```bash
+git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
+git commit -m "fix(matrix): handle room media and encrypted media event classes"
+```
+
+### Task 4: Validate mention-policy behavior for media events
+
+**Files:**
+- Modify: `squidbot/adapters/channels/matrix.py`
+- Modify: `tests/adapters/channels/test_matrix.py`
+
+**Step 1: Write failing media policy regression test**
+
+```python
+async def test_mention_policy_accepts_media_event_without_textual_mention_marker() -> None:
+    ...
+```
+
+**Step 2: Run to verify RED**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy_accepts_media_event" -v`
+Expected: FAIL.
+
+**Step 3: Implement minimal policy-safe logic**
+
+Do not drop media events solely due to missing textual mention marker.
+
+**Step 4: Re-run mention policy subset**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy" -v`
+Expected: PASS.
+
+**Step 5: Commit policy fix**
+
+```bash
+git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
+git commit -m "fix(matrix): avoid false mention-policy drops for media events"
+```
+
+### Task 5 (Conditional): Add BadEvent fallback if diagnostics prove callback miss
+
+**Files:**
+- Modify: `squidbot/adapters/channels/matrix.py`
+- Modify: `tests/adapters/channels/test_matrix.py`
+
+**Run only when logs show encrypted media bypassing both media callbacks.**
+
+**Step 1: Add failing fallback test**
+
+```python
+async def test_bad_event_with_media_shape_routes_to_media_pipeline() -> None:
+    ...
+```
+
+**Step 2: Verify RED**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "bad_event" -v`
+Expected: FAIL.
+
+**Step 3: Implement guarded fallback**
+
+Only route media-shaped bad events (`msgtype` media + `content.file.url`).
+
+**Step 4: Re-run fallback tests**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "bad_event" -v`
+Expected: PASS.
+
+**Step 5: Commit fallback**
+
+```bash
+git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
+git commit -m "fix(matrix): add guarded bad-event fallback for encrypted media"
+```
+
+### Task 6: Full verification
+
+**Files:**
+- Modify: none
+
+**Step 1: Run matrix adapter suite**
+
+Run: `uv run pytest tests/adapters/channels/test_matrix.py -v`
+Expected: PASS.
+
+**Step 2: Run lint**
+
+Run: `uv run ruff check .`
+Expected: PASS.
+
+**Step 3: Run format check**
+
+Run: `uv run ruff format . --check`
+Expected: PASS.
+
+**Step 4: Run typing**
+
+Run: `uv run mypy squidbot/`
+Expected: PASS.
+
+**Step 5: Run full tests**
+
+Run: `uv run pytest`
+Expected: PASS.
+
+**Step 6: Final commit (if needed)**
+
+```bash
+git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
+git commit -m "fix(matrix): ensure encrypted inbound file uploads reach agent context"
+```

--- a/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
+++ b/docs/plans/2026-03-01-matrix-encrypted-media-intake-implementation-plan.md
@@ -4,10 +4,14 @@
 
 **Goal:** Ensure encrypted and unencrypted Matrix uploads are consistently surfaced to the agent.
 
-**Architecture:** Add diagnostics first, then implement dual media callback handling and
-normalized encrypted payload extraction in the Matrix adapter. Keep current guardrails,
-validate mention-policy media behavior, and add a `BadEvent` fallback only if logs prove
-callback miss.
+**Architecture:** Fix two separate failure modes: (A) register `RoomEncryptedMedia` callback for
+E2EE Megolm rooms, (B) add `BadEvent` fallback for non-E2EE clients using `content.file` shape.
+Fix the pre-existing `decrypt_attachment` call-site bug (dict arg → positional string args).
+Add diagnostics. Preserve mention-policy safety.
+
+**Reference implementation:** `~/projects/nanobot-redux/nanobot/channels/matrix.py` — this has
+a working dual-callback setup (`MATRIX_MEDIA_EVENT_FILTER = (RoomMessageMedia, RoomEncryptedMedia)`)
+and correct `_decrypt_media_bytes` using positional string args. Port the relevant patterns.
 
 **Tech Stack:** Python 3.14, matrix-nio, Loguru, pytest, mypy --strict, ruff.
 
@@ -18,74 +22,108 @@ callback miss.
 **Files:**
 - Modify: `tests/adapters/channels/test_matrix.py`
 
-**Step 1: Write failing callback coverage test**
+**Step 1: Write failing callback registration test**
 
-Assert both that `nio.RoomEncryptedMedia` is registered AND that it is registered with
-`_handle_media` specifically (not another handler):
+Assert that `(RoomMessageMedia, RoomEncryptedMedia)` tuple is registered with `_handle_media`,
+AND that `BadEvent` is registered with `_handle_bad_event`:
 
 ```python
-async def test_registers_room_message_and_room_encrypted_media_callbacks() -> None:
-    # assert nio.RoomEncryptedMedia in registered_types
+async def test_registers_room_message_media_encrypted_media_and_bad_event_callbacks() -> None:
     # assert any(
-    #     c.args == (ch._handle_media, nio.RoomEncryptedMedia)
+    #     c.args == (ch._handle_media,) and
+    #     set(c.args[1]) == {nio.RoomMessageMedia, nio.RoomEncryptedMedia}  # tuple filter
     #     for c in fake_client.add_event_callback.call_args_list
-    # ), "RoomEncryptedMedia must be registered with _handle_media, not another handler"
+    # )
+    # assert any(
+    #     c.args == (ch._handle_bad_event, nio.BadEvent)
+    #     for c in fake_client.add_event_callback.call_args_list
+    # )
     ...
 ```
 
-**Step 2: Write failing encrypted payload test (third URL fallback)**
-
-This tests the shape where `event.url = ""`, `event.file = None`, but
-`source["content"]["file"]["url"]` contains the mxc URL:
+**Step 2: Write failing test — BadEvent with media shape routes to pipeline**
 
 ```python
-async def test_encrypted_file_with_content_file_url_is_processed() -> None:
-    # event.url = "", event.file = None
-    # event.source["content"]["file"]["url"] = "mxc://..."
-    # assert download called with correct server_name and media_id
+async def test_bad_event_with_media_shape_routes_to_media_pipeline() -> None:
+    # event = nio.BadEvent with source["content"] = {
+    #     "msgtype": "m.file", "body": "doc.pdf",
+    #     "file": {"url": "mxc://example.com/abc", "key": {...}, "iv": "...", "hashes": {...}}
+    # }
+    # assert InboundMessage queued with attachment
     ...
 ```
 
-**Step 3: Write failing encrypted payload test (key material from source)**
-
-Tests the case where key material (`key`, `iv`, `hashes`) is in `source["content"]["file"]`
-and `event.file is None`:
+**Step 3: Write failing test — non-media BadEvent is ignored**
 
 ```python
-async def test_encrypted_file_key_material_extracted_from_source_when_event_file_is_none() -> None:
-    # event.file = None, event.url = ""
-    # event.source["content"]["file"] = {"url": "mxc://...", "key": {...}, "iv": "...", "hashes": {...}}
-    # assert decrypt called with key material from source
+async def test_bad_event_without_media_shape_is_ignored() -> None:
+    # event = nio.BadEvent with source["content"] = {"msgtype": "m.text", "body": "hi"}
+    # assert no InboundMessage queued
     ...
 ```
 
-**Step 4: Write failing mention-policy media test**
+**Step 4: Write failing test — RoomEncryptedMedia decrypt uses positional string args**
+
+```python
+async def test_room_encrypted_media_decrypt_uses_key_k_and_hashes_sha256() -> None:
+    # event = nio.RoomEncryptedFile with:
+    #   event.url = "mxc://example.com/enc"
+    #   event.key = {"k": "base64key", "kty": "oct", ...}
+    #   event.hashes = {"sha256": "base64hash"}
+    #   event.iv = "base64iv"
+    # mock decrypt_attachment, assert called with (ciphertext, "base64key", "base64hash", "base64iv")
+    # NOT called with a dict
+    ...
+```
+
+**Step 5: Write failing test — BadEvent decrypt uses source["content"]["file"] key material**
+
+```python
+async def test_bad_event_media_decrypt_uses_source_content_file_key_material() -> None:
+    # BadEvent with source["content"]["file"] = {
+    #   "url": "mxc://...", "key": {"k": "base64key", ...},
+    #   "iv": "base64iv", "hashes": {"sha256": "base64hash"}
+    # }
+    # mock decrypt_attachment, assert called with positional strings from file dict
+    ...
+```
+
+**Step 6: Write failing mention-policy media test**
 
 ```python
 async def test_media_event_not_dropped_only_due_to_filename_without_mention() -> None:
+    # group_policy = "mention", event msgtype in {m.image, m.file, m.audio, m.video}
+    # event.body = "photo.jpg" (no bot mention)
+    # assert event is accepted
     ...
 ```
 
-**Step 5: Write test for malformed declared_size**
+**Step 7: Write failing test — malformed declared_size does not block download**
 
 ```python
 async def test_malformed_declared_size_does_not_block_download() -> None:
     # event.info.size = "not-a-number"
-    # assert download is still attempted (post-fetch guard applies, preflight guard bypassed)
+    # assert download is still attempted (post-fetch guard applies)
     ...
 ```
 
-**Step 6: Run tests to verify RED**
+**Step 8: Run tests to verify RED**
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file or callback or mention or declared_size" -v`
-Expected: FAIL.
+```
+uv run pytest tests/adapters/channels/test_matrix.py \
+  -k "bad_event or encrypted_media or callback or mention or declared_size" -v
+```
 
-**Step 7: Commit red tests**
+Expected: FAIL on all new tests.
+
+**Step 9: Commit red tests**
 
 ```bash
 git add tests/adapters/channels/test_matrix.py
 git commit -m "test(matrix): add failing encrypted media intake coverage"
 ```
+
+---
 
 ### Task 2: Add parser/routing diagnostics
 
@@ -95,27 +133,29 @@ git commit -m "test(matrix): add failing encrypted media intake coverage"
 
 **Step 1: Write failing diagnostic assertion test**
 
-Assert the exact log format strings from the design doc:
-
 ```python
 async def test_debug_logs_include_event_class_and_media_shape() -> None:
     # capture loguru output at DEBUG level
-    # assert log contains: "MatrixChannel: classify event=... class=... msgtype=... has_url=... has_file_url=... has_key_material=..."
-    # assert log contains: "MatrixChannel: policy event=... result=... reason=..."
+    # assert log contains:
+    #   "MatrixChannel: classify event=... class=... msgtype=... has_url=... has_file_url=... has_key_material=..."
+    #   "MatrixChannel: policy event=... result=... reason=..."
     ...
 ```
 
 **Step 2: Run to verify RED**
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "debug_logs_include_event_class" -v`
+```
+uv run pytest tests/adapters/channels/test_matrix.py -k "debug_logs_include_event_class" -v
+```
+
 Expected: FAIL.
 
 **Step 3: Implement debug logging boundaries**
 
-Add `logger.debug(...)` at five boundaries using the exact log format from the design doc:
+Add `logger.debug(...)` at five boundaries using exact log format from design doc:
 
 | Boundary | Log format |
-|----------|------------|
+|---|---|
 | Callback registration | `"MatrixChannel: registered callbacks classes={}"` |
 | Event classification | `"MatrixChannel: classify event={} class={} msgtype={} has_url={} has_file_url={} has_key_material={}"` |
 | Policy decision | `"MatrixChannel: policy event={} result={} reason={}"` |
@@ -125,9 +165,12 @@ Add `logger.debug(...)` at five boundaries using the exact log format from the d
 Reason codes: `accepted`, `policy_filtered`, `missing_media_url`, `decryption_failed`,
 `size_exceeded`, `embedded`, `not_embedded`.
 
-**Step 4: Re-run diagnostic tests**
+**Step 4: Re-run diagnostic test**
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "debug_logs_include_event_class" -v`
+```
+uv run pytest tests/adapters/channels/test_matrix.py -k "debug_logs_include_event_class" -v
+```
+
 Expected: PASS.
 
 **Step 5: Commit diagnostics**
@@ -137,60 +180,94 @@ git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix
 git commit -m "feat(matrix): add inbound media parser diagnostics"
 ```
 
-### Task 3: Implement dual callback handling + normalized extraction
+---
+
+### Task 3: Implement dual callback registration + fix decrypt call
 
 **Files:**
 - Modify: `squidbot/adapters/channels/matrix.py`
-- Modify: `tests/adapters/channels/test_matrix.py`
 
-**Step 1: Register both callback classes**
-
-- `nio.RoomMessageMedia`
-- `nio.RoomEncryptedMedia` — registered with `_handle_media`
-
-**Step 2: Implement `_extract_media_url` helper**
-
-Three-level URL fallback with safe `.get()` access throughout:
+**Step 1: Define `MEDIA_EVENT_FILTER` constant**
 
 ```python
-def _extract_media_url(event: Any) -> str:
-    """Return the first non-empty mxc:// URL from event using three-level fallback."""
-    return (
-        getattr(event, "url", "") or
-        getattr(getattr(event, "file", None), "url", "") or
-        event.source.get("content", {}).get("file", {}).get("url", "") or
-        ""
-    )
+MEDIA_EVENT_FILTER = (nio.RoomMessageMedia, nio.RoomEncryptedMedia)
 ```
 
-**Step 3: Implement key-material extraction helper**
-
-When `event.file is None`, extract key material from `source["content"]["file"]`:
+**Step 2: Register callbacks in `_register_callbacks`**
 
 ```python
-def _extract_key_material(event: Any) -> tuple[dict, str, dict] | None:
-    """Return (key, iv, hashes) from event or source, or None if unavailable."""
-    if getattr(event, "key", None):
-        return event.key, event.iv, event.hashes
-    source_file = event.source.get("content", {}).get("file", {})
-    if source_file.get("key"):
-        return source_file["key"], source_file["iv"], source_file["hashes"]
-    return None
+self._client.add_event_callback(self._handle_media, MEDIA_EVENT_FILTER)
+self._client.add_event_callback(self._handle_bad_event, nio.BadEvent)
 ```
 
-**Step 4: Route both classes through same media processing path**
+**Step 3: Implement `_handle_bad_event`**
 
-**Step 5: Run focused tests**
+```python
+async def _handle_bad_event(self, room: nio.MatrixRoom, event: nio.BadEvent) -> None:
+    """Route media-shaped BadEvent into the media pipeline; ignore all others."""
+    if not _is_media_shaped_bad_event(event):
+        return
+    # delegate to shared media processing path
+```
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "encrypted_file or callback" -v`
+**Step 4: Implement `_is_media_shaped_bad_event`**
+
+```python
+MEDIA_MSGTYPES = {"m.image", "m.file", "m.audio", "m.video"}
+
+def _is_media_shaped_bad_event(event: nio.BadEvent) -> bool:
+    content = event.source.get("content", {})
+    msgtype = content.get("msgtype", "")
+    has_file_url = bool(content.get("file", {}).get("url", ""))
+    return msgtype in MEDIA_MSGTYPES and has_file_url
+```
+
+**Step 5: Fix `decrypt_attachment` call (pre-existing bug at line ~773)**
+
+Replace the dict-based call with positional string extraction. For `RoomEncryptedMedia`
+events (direct attrs):
+
+```python
+from nio.crypto.attachments import decrypt_attachment
+from nio.exceptions import EncryptionError
+
+key = event.key.get("k") if isinstance(event.key, dict) else None
+sha256 = event.hashes.get("sha256") if isinstance(event.hashes, dict) else None
+iv = event.iv if isinstance(event.iv, str) else None
+if not (key and sha256 and iv):
+    # log warning, return error marker
+body = decrypt_attachment(body, key, sha256, iv)
+```
+
+For `BadEvent` (source dict path):
+
+```python
+content_file = event.source["content"]["file"]
+key = content_file.get("key", {}).get("k")
+sha256 = content_file.get("hashes", {}).get("sha256")
+iv = content_file.get("iv")
+if not (key and sha256 and iv):
+    # log warning, return error marker
+body = decrypt_attachment(body, key, sha256, iv)
+```
+
+**Step 6: Run focused tests**
+
+```
+uv run pytest tests/adapters/channels/test_matrix.py \
+  -k "bad_event or callback or encrypted_media" -v
+```
+
 Expected: PASS.
 
-**Step 6: Commit implementation**
+**Step 7: Commit**
 
 ```bash
 git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
-git commit -m "fix(matrix): handle room media and encrypted media event classes"
+git commit -m "fix(matrix): register RoomEncryptedMedia callback and BadEvent fallback"
 ```
+
+---
 
 ### Task 4: Validate mention-policy behavior for media events
 
@@ -198,25 +275,17 @@ git commit -m "fix(matrix): handle room media and encrypted media event classes"
 - Modify: `squidbot/adapters/channels/matrix.py`
 - Modify: `tests/adapters/channels/test_matrix.py`
 
-**Step 1: Write failing media policy regression tests**
+**Step 1: Run failing mention-policy test from Task 1 Step 6**
 
-Test all four media msgtypes:
-
-```python
-async def test_mention_policy_accepts_media_event_without_textual_mention_marker() -> None:
-    # m.image, m.file, m.audio, m.video — all must be accepted in mention-policy rooms
-    # even when body (filename) contains no bot mention
-    ...
+```
+uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy" -v
 ```
 
-**Step 2: Run to verify RED**
-
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy_accepts_media_event" -v`
 Expected: FAIL.
 
-**Step 3: Implement mention-policy fix in `_accept_event`**
+**Step 2: Add `MEDIA_MSGTYPES` bypass in `_accept_event`**
 
-Before the body-based mention check, add:
+Before the body-based mention check:
 
 ```python
 MEDIA_MSGTYPES = {"m.image", "m.file", "m.audio", "m.video"}
@@ -226,15 +295,15 @@ if msgtype in MEDIA_MSGTYPES:
     return True  # skip mention check for all media uploads
 ```
 
-This bypasses the mention check for all four media msgtypes. Text events (`m.text`,
-`m.notice`, `m.emote`) continue to require a textual mention.
+**Step 3: Re-run mention-policy tests**
 
-**Step 4: Re-run mention policy subset**
+```
+uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy" -v
+```
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "mention_policy" -v`
 Expected: PASS.
 
-**Step 5: Commit policy fix**
+**Step 4: Commit**
 
 ```bash
 git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
@@ -243,78 +312,49 @@ git commit -m "fix(matrix): avoid false mention-policy drops for media events"
 
 ---
 
-**Decision gate (Task 5 trigger):** After deploying Task 3 and Task 4, run
-`LOG_LEVEL=DEBUG uv run squidbot gateway` and send an encrypted file from a Matrix client.
-Search logs for `MatrixChannel: _handle_media`. If no such line appears for the upload event,
-proceed to Task 5. If `_handle_media` is called, mark Task 5 as skipped and proceed to Task 6.
-
----
-
-### Task 5 (Conditional): Add BadEvent fallback if diagnostics prove callback miss
-
-**Files:**
-- Modify: `squidbot/adapters/channels/matrix.py`
-- Modify: `tests/adapters/channels/test_matrix.py`
-
-**Only run if the Task 5 decision gate above is triggered (no `_handle_media` log appears).**
-
-**Step 1: Add failing fallback test**
-
-```python
-async def test_bad_event_with_media_shape_routes_to_media_pipeline() -> None:
-    ...
-```
-
-**Step 2: Verify RED**
-
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "bad_event" -v`
-Expected: FAIL.
-
-**Step 3: Implement guarded fallback**
-
-Only route media-shaped bad events (`msgtype` in `MEDIA_MSGTYPES` + `content.file.url`
-or `content.url`).
-
-**Step 4: Re-run fallback tests**
-
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -k "bad_event" -v`
-Expected: PASS.
-
-**Step 5: Commit fallback**
-
-```bash
-git add squidbot/adapters/channels/matrix.py tests/adapters/channels/test_matrix.py
-git commit -m "fix(matrix): add guarded bad-event fallback for encrypted media"
-```
-
-### Task 6: Full verification
+### Task 5: Full verification
 
 **Files:**
 - Modify: none
 
-**Step 1: Run matrix adapter suite**
+**Step 1: Run full matrix adapter suite**
 
-Run: `uv run pytest tests/adapters/channels/test_matrix.py -v`
-Expected: PASS.
+```
+uv run pytest tests/adapters/channels/test_matrix.py -v
+```
+
+Expected: all PASS.
 
 **Step 2: Run lint**
 
-Run: `uv run ruff check .`
+```
+uv run ruff check .
+```
+
 Expected: PASS.
 
 **Step 3: Run format check**
 
-Run: `uv run ruff format . --check`
+```
+uv run ruff format . --check
+```
+
 Expected: PASS.
 
-**Step 4: Run typing**
+**Step 4: Run type-check**
 
-Run: `uv run mypy squidbot/`
+```
+uv run mypy squidbot/
+```
+
 Expected: PASS.
 
-**Step 5: Run full tests**
+**Step 5: Run full test suite**
 
-Run: `uv run pytest`
+```
+uv run pytest
+```
+
 Expected: PASS.
 
 **Step 6: Final integration commit**

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -38,6 +38,15 @@ _TYPING_TIMEOUT_MS: int = 30_000
 _TYPING_KEEPALIVE_S: float = 25.0
 _TYPING_RETRY_DEFAULT_S: float = 5.0
 
+# Event types registered as nio callbacks — used for both registration and diagnostic logging
+# so the two cannot silently diverge.
+_REGISTERED_EVENT_TYPES: tuple[type, ...] = (
+    nio.RoomMessageText,
+    nio.RoomMessageMedia,
+    nio.InviteMemberEvent,
+    nio.UnknownEvent,
+)
+
 # MIME types eligible for Base64 embedding in LLM multimodal content.
 # SVG is explicitly excluded — it is XML-based and may cause provider handling issues.
 EMBEDDABLE_IMAGE_MIMES: frozenset[str] = frozenset(
@@ -331,15 +340,10 @@ class MatrixChannel:
         client.add_event_callback(self._handle_invite, cast(Any, nio.InviteMemberEvent))
         # Keep UnknownEvent for reaction parsing and encrypted-event diagnostics.
         client.add_event_callback(self._handle_reaction, nio.UnknownEvent)
-        registered_classes = [
-            nio.RoomMessageText,
-            nio.RoomMessageMedia,
-            nio.InviteMemberEvent,
-            nio.UnknownEvent,
-        ]
+        # Log using _REGISTERED_EVENT_TYPES so the diagnostic cannot diverge from reality.
         logger.debug(
             "MatrixChannel: registered callbacks classes={}",
-            [c.__name__ for c in registered_classes],
+            [c.__name__ for c in _REGISTERED_EVENT_TYPES],
         )
         self._client = client
         self._sync_start_ms = int(datetime.now().timestamp() * 1000)
@@ -406,7 +410,7 @@ class MatrixChannel:
             policy_result = "accepted"
             policy_reason = "accepted"
         else:
-            policy_result = "filtered"
+            policy_result = "rejected"
             policy_reason = "policy_filtered"
         logger.debug(
             "MatrixChannel: policy event={} result={} reason={}",

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -840,19 +840,17 @@ class MatrixChannel:
             Tuple of (text_description, multimodal_content_or_None).
         """
         assert self._client is not None
+        # RoomEncryptedMedia and RoomMessageMedia both expose the mxc URL as event.url.
         mxc: str = getattr(event, "url", "") or ""
-        enc_file = getattr(event, "file", None)
-        if enc_file:
-            mxc = enc_file.url
 
         # Fallback: BadEvent or event with content.file instead of content.url.
-        # nio cannot parse such events and returns them with no url/file attributes;
+        # nio cannot parse such events and returns them with no url attribute;
         # extract the mxc URL directly from the event source in that case.
         source_content: dict[str, Any] = getattr(event, "source", {}).get("content", {})
         source_file: dict[str, Any] = (
             source_content.get("file", {}) if isinstance(source_content.get("file"), dict) else {}
         )
-        if not mxc and enc_file is None:
+        if not mxc:
             mxc = source_file.get("url", "") or ""
 
         # Parse mxc://server/mediaid
@@ -913,7 +911,7 @@ class MatrixChannel:
         event_id_val = getattr(event, "event_id", "?")
         # RoomEncryptedMedia exposes key/hashes/iv as direct event attributes.
         has_direct_enc_attrs = isinstance(getattr(event, "key", None), dict)
-        is_encrypted = enc_file is not None or has_direct_enc_attrs or bool(source_file)
+        is_encrypted = has_direct_enc_attrs or bool(source_file)
         logger.debug(
             "MatrixChannel: download event={} encrypted={} url={}",
             event_id_val,
@@ -927,28 +925,9 @@ class MatrixChannel:
 
         body = cast(bytes, resp.body)
 
-        # Decrypt if E2EE via event.file (nested EncryptedFile object on the event).
-        if enc_file is not None:
-            from nio.crypto.attachments import decrypt_attachment  # noqa: PLC0415
-
-            enc_key: str | None = (
-                enc_file.key.get("k")
-                if isinstance(enc_file.key, dict)
-                else getattr(enc_file.key, "k", None)
-            )
-            enc_hashes = getattr(enc_file, "hashes", None)
-            enc_sha256: str | None = (
-                enc_hashes.get("sha256") if isinstance(enc_hashes, dict) else None
-            )
-            enc_iv: str | None = enc_file.iv if isinstance(enc_file.iv, str) else None
-            if enc_key and enc_sha256 and enc_iv:
-                body = decrypt_attachment(body, enc_key, enc_sha256, enc_iv)
-            else:
-                logger.warning(
-                    "MatrixChannel: missing E2EE key material for event={}, skipping decrypt",
-                    event_id_val,
-                )
-        elif has_direct_enc_attrs:
+        # Decrypt if E2EE: RoomEncryptedMedia exposes key/hashes/iv as direct event attributes
+        # (parsed from content.file.* by nio; no event.file attribute on that class).
+        if has_direct_enc_attrs:
             # Decrypt via RoomEncryptedMedia direct attributes: key/hashes/iv live on the event
             # itself (parsed from content.file.* by nio), not nested under event.file.
             from nio.crypto.attachments import decrypt_attachment  # noqa: PLC0415

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -640,6 +640,12 @@ class MatrixChannel:
         if self._config.room_ids and room_id not in self._config.room_ids:
             logger.debug("MatrixChannel: drop room filter event={} room={}", event_id, room_id)
             return False
+        # Media events have filenames (e.g. "photo.jpg") as their body, which never contains
+        # an @mention. Skip the mention check for all media msgtypes so they are not silently
+        # dropped in "mention" policy rooms.
+        msgtype: str = event.source.get("content", {}).get("msgtype", "")
+        if msgtype in MEDIA_MSGTYPES:
+            return True  # skip mention check for all media uploads
         body: str = getattr(event, "body", "")
         policy = self._config.group_policy
         if policy == "open":

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -43,9 +43,17 @@ _TYPING_RETRY_DEFAULT_S: float = 5.0
 _REGISTERED_EVENT_TYPES: tuple[type, ...] = (
     nio.RoomMessageText,
     nio.RoomMessageMedia,
+    nio.RoomEncryptedMedia,
     nio.InviteMemberEvent,
     nio.UnknownEvent,
+    nio.BadEvent,
 )
+
+# Tuple passed to add_event_callback so _handle_media fires for both plain and E2EE media.
+MEDIA_EVENT_FILTER: tuple[type, type] = (nio.RoomMessageMedia, nio.RoomEncryptedMedia)
+
+# Matrix media msgtypes whose content may carry encrypted-file key material.
+MEDIA_MSGTYPES: frozenset[str] = frozenset({"m.image", "m.file", "m.audio", "m.video"})
 
 # MIME types eligible for Base64 embedding in LLM multimodal content.
 # SVG is explicitly excluded — it is XML-based and may cause provider handling issues.
@@ -54,6 +62,25 @@ EMBEDDABLE_IMAGE_MIMES: frozenset[str] = frozenset(
 )
 
 _md = mistune.create_markdown(escape=True)
+
+
+def _is_media_shaped_bad_event(event: nio.BadEvent) -> bool:
+    """Return True if a BadEvent carries encrypted-file key material (m.image/file/audio/video).
+
+    nio cannot parse events where the client sends ``content.file`` instead of ``content.url``
+    (encrypted upload shape) and returns them as BadEvent. This predicate identifies those
+    so they can be routed through the media pipeline.
+
+    Args:
+        event: nio BadEvent to inspect.
+
+    Returns:
+        True when the event's content has a recognised media msgtype and a non-empty file URL.
+    """
+    content = event.source.get("content", {})
+    msgtype: str = content.get("msgtype", "")
+    has_file_url = bool(content.get("file", {}).get("url", ""))
+    return msgtype in MEDIA_MSGTYPES and has_file_url
 
 
 def _render_markdown(text: str) -> str:
@@ -334,7 +361,16 @@ class MatrixChannel:
                     load_exc,
                 )
         client.add_event_callback(self._handle_text, nio.RoomMessageText)
+        # Register _handle_media individually so both types appear in the callback list.
         client.add_event_callback(self._handle_media, nio.RoomMessageMedia)
+        client.add_event_callback(self._handle_media, cast(Any, nio.RoomEncryptedMedia))
+        # Also register via MEDIA_EVENT_FILTER tuple — required by the callback-registration
+        # contract tests that assert the tuple appears as a registered unit.
+        client.add_event_callback(self._handle_media, cast(Any, MEDIA_EVENT_FILTER))
+        # Register _handle_bad_event for events nio cannot parse (encrypted-upload shape).
+        # cast(Any, ...) on the callback silences the contravariant signature mismatch —
+        # nio dispatches BadEvent at runtime but the static type expects the wide Event type.
+        client.add_event_callback(cast(Any, self._handle_bad_event), cast(Any, nio.BadEvent))
         # matrix-nio callback typing does not accept InviteMemberEvent here, even though
         # runtime dispatch works; keep this cast as a type-checking workaround.
         client.add_event_callback(self._handle_invite, cast(Any, nio.InviteMemberEvent))
@@ -489,6 +525,42 @@ class MatrixChannel:
             self._queue.put_nowait(
                 InboundMessage(session=session, text=f"[Reaktion: {key}]", metadata=metadata)
             )
+
+    async def _handle_bad_event(self, room: nio.MatrixRoom, event: nio.BadEvent) -> None:
+        """Route media-shaped BadEvent into the media pipeline; ignore all others.
+
+        nio returns BadEvent when it cannot parse an event against its schema.
+        This happens for encrypted uploads where the client sends ``content.file``
+        instead of ``content.url`` — the schema validator rejects them. We detect
+        such events via _is_media_shaped_bad_event and delegate to the shared
+        media processing path.
+
+        Args:
+            room: The Matrix room the event was received in.
+            event: The BadEvent to inspect and potentially route.
+        """
+        if not _is_media_shaped_bad_event(event):
+            return
+        if not self._accept_event(room, event):
+            return
+        assert self._client is not None
+        try:
+            text, multimodal_content = await self._download_attachment(event)
+        except Exception as exc:  # noqa: BLE001
+            text = f"[Anhang nicht verfügbar: {exc}]"
+            multimodal_content = None
+        metadata = self._extract_metadata(event)
+        session = Session(channel="matrix", sender_id=event.sender)
+        room_id: str = getattr(event, "room_id", getattr(room, "room_id", ""))
+        self._session_rooms[session.id] = room_id
+        self._queue.put_nowait(
+            InboundMessage(
+                session=session,
+                text=text,
+                metadata=metadata,
+                multimodal_content=multimodal_content,
+            )
+        )
 
     async def _handle_invite(self, room: Any, event: Any) -> None:
         """Auto-join invitations from allowlisted owner Matrix IDs."""
@@ -760,17 +832,31 @@ class MatrixChannel:
         if enc_file:
             mxc = enc_file.url
 
+        # Fallback: BadEvent or event with content.file instead of content.url.
+        # nio cannot parse such events and returns them with no url/file attributes;
+        # extract the mxc URL directly from the event source in that case.
+        source_content: dict[str, Any] = getattr(event, "source", {}).get("content", {})
+        source_file: dict[str, Any] = (
+            source_content.get("file", {}) if isinstance(source_content.get("file"), dict) else {}
+        )
+        if not mxc and enc_file is None:
+            mxc = source_file.get("url", "") or ""
+
         # Parse mxc://server/mediaid
         if not mxc.startswith("mxc://"):
             return "[Anhang: ungültige mxc URI]", None
         mxc_body = mxc[len("mxc://") :]
         server, _, media_id = mxc_body.partition("/")
 
-        filename: str = getattr(event, "body", "attachment")
+        filename: str = getattr(event, "body", "") or source_content.get("body", "attachment")
         info_obj = getattr(event, "info", None)
         declared_mime: str = (
             (getattr(info_obj, "mimetype", None) or "") if info_obj is not None else ""
         )
+        if not declared_mime:
+            # Try source content info for events like BadEvent
+            src_info = source_content.get("info", {})
+            declared_mime = src_info.get("mimetype", "") if isinstance(src_info, dict) else ""
         max_download = self._config.max_inbound_download_bytes
         max_embed = self._config.max_inbound_embed_bytes
 
@@ -791,9 +877,28 @@ class MatrixChannel:
                         "exceeds_download_limit_preflight",
                     )
                     return f"[Anhang: {filename} — zu groß]", None
+        # Also apply preflight guard for size declared in source content (BadEvent path).
+        if info_obj is None and source_file:
+            src_info = source_content.get("info", {})
+            if isinstance(src_info, dict):
+                src_declared_size = src_info.get("size")
+                if src_declared_size is not None:
+                    try:
+                        src_ds = int(src_declared_size)
+                    except TypeError, ValueError:
+                        src_ds = 0
+                    if src_ds > max_download:
+                        logger.debug(
+                            "MatrixChannel: skip download mxc={} file={} size={} reason={}",
+                            mxc,
+                            filename,
+                            src_ds,
+                            "exceeds_download_limit_preflight",
+                        )
+                        return f"[Anhang: {filename} — zu groß]", None
 
         event_id_val = getattr(event, "event_id", "?")
-        is_encrypted = enc_file is not None
+        is_encrypted = enc_file is not None or bool(source_file)
         logger.debug(
             "MatrixChannel: download event={} encrypted={} url={}",
             event_id_val,
@@ -807,25 +912,48 @@ class MatrixChannel:
 
         body = cast(bytes, resp.body)
 
-        # Decrypt if E2EE
+        # Decrypt if E2EE via event.file (RoomEncryptedMedia-style: direct attribute access).
         if enc_file is not None:
             from nio.crypto.attachments import decrypt_attachment  # noqa: PLC0415
 
-            key_info = {
-                "url": enc_file.url,
-                "key": {
-                    "kty": enc_file.key.key_type,
-                    "alg": enc_file.key.alg,
-                    "k": enc_file.key.k,
-                    "key_ops": enc_file.key.key_ops,
-                    "ext": enc_file.key.ext,
-                },
-                "iv": enc_file.iv,
-                "hashes": enc_file.hashes,
-                "v": enc_file.v,
-            }
-            decrypt_attachment_fn: Any = decrypt_attachment
-            body = decrypt_attachment_fn(body, key_info)
+            enc_key: str | None = (
+                enc_file.key.get("k")
+                if isinstance(enc_file.key, dict)
+                else getattr(enc_file.key, "k", None)
+            )
+            enc_hashes = getattr(enc_file, "hashes", None)
+            enc_sha256: str | None = (
+                enc_hashes.get("sha256") if isinstance(enc_hashes, dict) else None
+            )
+            enc_iv: str | None = enc_file.iv if isinstance(enc_file.iv, str) else None
+            if enc_key and enc_sha256 and enc_iv:
+                body = decrypt_attachment(body, enc_key, enc_sha256, enc_iv)
+            else:
+                logger.warning(
+                    "MatrixChannel: missing E2EE key material for event={}, skipping decrypt",
+                    event_id_val,
+                )
+        elif source_file:
+            # Decrypt via BadEvent source path: key material lives in source["content"]["file"].
+            from nio.crypto.attachments import decrypt_attachment  # noqa: PLC0415
+
+            src_key_dict: dict[str, Any] = (
+                source_file.get("key", {}) if isinstance(source_file.get("key"), dict) else {}
+            )
+            src_key: str | None = src_key_dict.get("k") or None
+            src_hashes: dict[str, Any] = (
+                source_file.get("hashes", {}) if isinstance(source_file.get("hashes"), dict) else {}
+            )
+            src_sha256: str | None = src_hashes.get("sha256") or None
+            src_iv: str | None = source_file.get("iv") or None
+            if src_key and src_sha256 and src_iv:
+                body = decrypt_attachment(body, src_key, src_sha256, src_iv)
+            else:
+                logger.warning(
+                    "MatrixChannel: missing E2EE key material in source for event={}, "
+                    "skipping decrypt",
+                    event_id_val,
+                )
 
         raw_bytes = len(body)
         logger.debug(

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -911,7 +911,9 @@ class MatrixChannel:
                         return f"[Anhang: {filename} — zu groß]", None
 
         event_id_val = getattr(event, "event_id", "?")
-        is_encrypted = enc_file is not None or bool(source_file)
+        # RoomEncryptedMedia exposes key/hashes/iv as direct event attributes.
+        has_direct_enc_attrs = isinstance(getattr(event, "key", None), dict)
+        is_encrypted = enc_file is not None or has_direct_enc_attrs or bool(source_file)
         logger.debug(
             "MatrixChannel: download event={} encrypted={} url={}",
             event_id_val,
@@ -925,7 +927,7 @@ class MatrixChannel:
 
         body = cast(bytes, resp.body)
 
-        # Decrypt if E2EE via event.file (RoomEncryptedMedia-style: direct attribute access).
+        # Decrypt if E2EE via event.file (nested EncryptedFile object on the event).
         if enc_file is not None:
             from nio.crypto.attachments import decrypt_attachment  # noqa: PLC0415
 
@@ -944,6 +946,29 @@ class MatrixChannel:
             else:
                 logger.warning(
                     "MatrixChannel: missing E2EE key material for event={}, skipping decrypt",
+                    event_id_val,
+                )
+        elif has_direct_enc_attrs:
+            # Decrypt via RoomEncryptedMedia direct attributes: key/hashes/iv live on the event
+            # itself (parsed from content.file.* by nio), not nested under event.file.
+            from nio.crypto.attachments import decrypt_attachment  # noqa: PLC0415
+
+            direct_key_dict: dict[str, Any] = getattr(event, "key", {}) or {}
+            direct_key: str | None = (
+                direct_key_dict.get("k") if isinstance(direct_key_dict, dict) else None
+            ) or None
+            direct_hashes: dict[str, Any] = getattr(event, "hashes", {}) or {}
+            direct_sha256: str | None = (
+                direct_hashes.get("sha256") if isinstance(direct_hashes, dict) else None
+            ) or None
+            direct_iv_raw = getattr(event, "iv", None)
+            direct_iv: str | None = direct_iv_raw if isinstance(direct_iv_raw, str) else None
+            if direct_key and direct_sha256 and direct_iv:
+                body = decrypt_attachment(body, direct_key, direct_sha256, direct_iv)
+            else:
+                logger.warning(
+                    "MatrixChannel: missing E2EE key material on event attrs for event={}, "
+                    "skipping decrypt",
                     event_id_val,
                 )
         elif source_file:

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -38,15 +38,16 @@ _TYPING_TIMEOUT_MS: int = 30_000
 _TYPING_KEEPALIVE_S: float = 25.0
 _TYPING_RETRY_DEFAULT_S: float = 5.0
 
-# Event types registered as nio callbacks — used for both registration and diagnostic logging
-# so the two cannot silently diverge.
+# Event types covered by registered nio callbacks — used for diagnostic logging so the
+# two cannot silently diverge. MEDIA_EVENT_FILTER expands to RoomMessageMedia +
+# RoomEncryptedMedia; BadEvent handles encrypted-upload events that fail schema validation.
 _REGISTERED_EVENT_TYPES: tuple[type, ...] = (
     nio.RoomMessageText,
     nio.RoomMessageMedia,
     nio.RoomEncryptedMedia,
+    nio.BadEvent,
     nio.InviteMemberEvent,
     nio.UnknownEvent,
-    nio.BadEvent,
 )
 
 # Tuple passed to add_event_callback so _handle_media fires for both plain and E2EE media.
@@ -361,11 +362,9 @@ class MatrixChannel:
                     load_exc,
                 )
         client.add_event_callback(self._handle_text, nio.RoomMessageText)
-        # Register _handle_media individually so both types appear in the callback list.
-        client.add_event_callback(self._handle_media, nio.RoomMessageMedia)
-        client.add_event_callback(self._handle_media, cast(Any, nio.RoomEncryptedMedia))
-        # Also register via MEDIA_EVENT_FILTER tuple — required by the callback-registration
-        # contract tests that assert the tuple appears as a registered unit.
+        # Register _handle_media for both plain and E2EE (Megolm-decrypted) media events.
+        # MEDIA_EVENT_FILTER is a tuple so nio fires _handle_media for either type with a
+        # single registration, preventing double-dispatch.
         client.add_event_callback(self._handle_media, cast(Any, MEDIA_EVENT_FILTER))
         # Register _handle_bad_event for events nio cannot parse (encrypted-upload shape).
         # cast(Any, ...) on the callback silences the contravariant signature mismatch —
@@ -462,6 +461,25 @@ class MatrixChannel:
         except Exception as exc:  # noqa: BLE001
             text = f"[Anhang nicht verfügbar: {exc}]"
             multimodal_content = None
+        self._enqueue_media_message(room, event, text, multimodal_content)
+
+    def _enqueue_media_message(
+        self,
+        room: Any,
+        event: Any,
+        text: str,
+        multimodal_content: list[dict[str, Any]] | None,
+    ) -> None:
+        """Build an InboundMessage from a processed media event and add it to the queue.
+
+        Shared by _handle_media and _handle_bad_event to avoid duplicate queue-building logic.
+
+        Args:
+            room: The Matrix room the event was received in.
+            event: The media event (RoomMessageMedia, RoomEncryptedMedia, or BadEvent).
+            text: Text description of the attachment (path or error marker).
+            multimodal_content: Optional multimodal blocks for embeddable images.
+        """
         metadata = self._extract_metadata(event)
         session = Session(channel="matrix", sender_id=event.sender)
         room_id: str = getattr(event, "room_id", getattr(room, "room_id", ""))
@@ -549,18 +567,7 @@ class MatrixChannel:
         except Exception as exc:  # noqa: BLE001
             text = f"[Anhang nicht verfügbar: {exc}]"
             multimodal_content = None
-        metadata = self._extract_metadata(event)
-        session = Session(channel="matrix", sender_id=event.sender)
-        room_id: str = getattr(event, "room_id", getattr(room, "room_id", ""))
-        self._session_rooms[session.id] = room_id
-        self._queue.put_nowait(
-            InboundMessage(
-                session=session,
-                text=text,
-                metadata=metadata,
-                multimodal_content=multimodal_content,
-            )
-        )
+        self._enqueue_media_message(room, event, text, multimodal_content)
 
     async def _handle_invite(self, room: Any, event: Any) -> None:
         """Auto-join invitations from allowlisted owner Matrix IDs."""

--- a/squidbot/adapters/channels/matrix.py
+++ b/squidbot/adapters/channels/matrix.py
@@ -331,6 +331,16 @@ class MatrixChannel:
         client.add_event_callback(self._handle_invite, cast(Any, nio.InviteMemberEvent))
         # Keep UnknownEvent for reaction parsing and encrypted-event diagnostics.
         client.add_event_callback(self._handle_reaction, nio.UnknownEvent)
+        registered_classes = [
+            nio.RoomMessageText,
+            nio.RoomMessageMedia,
+            nio.InviteMemberEvent,
+            nio.UnknownEvent,
+        ]
+        logger.debug(
+            "MatrixChannel: registered callbacks classes={}",
+            [c.__name__ for c in registered_classes],
+        )
         self._client = client
         self._sync_start_ms = int(datetime.now().timestamp() * 1000)
         logger.info("MatrixChannel: connected as {}", cfg.user_id)
@@ -371,7 +381,40 @@ class MatrixChannel:
 
     async def _handle_media(self, room: Any, event: Any) -> None:
         """Handle an incoming m.room.message with a media msgtype."""
-        if not self._accept_event(room, event):
+        event_id = getattr(event, "event_id", "?")
+        event_class = type(event).__name__
+        content = getattr(event, "source", {}).get("content", {})
+        msgtype = content.get("msgtype") or getattr(event, "msgtype", "")
+        has_url = bool(getattr(event, "url", None))
+        enc_file = getattr(event, "file", None)
+        has_file_url = bool(enc_file and getattr(enc_file, "url", None))
+        has_key_material = bool(
+            enc_file and getattr(enc_file, "key", None) and getattr(enc_file.key, "k", None)
+        )
+        logger.debug(
+            "MatrixChannel: classify event={} class={} msgtype={} has_url={}"
+            " has_file_url={} has_key_material={}",
+            event_id,
+            event_class,
+            msgtype,
+            has_url,
+            has_file_url,
+            has_key_material,
+        )
+        accepted = self._accept_event(room, event)
+        if accepted:
+            policy_result = "accepted"
+            policy_reason = "accepted"
+        else:
+            policy_result = "filtered"
+            policy_reason = "policy_filtered"
+        logger.debug(
+            "MatrixChannel: policy event={} result={} reason={}",
+            event_id,
+            policy_result,
+            policy_reason,
+        )
+        if not accepted:
             return
         assert self._client is not None
         try:
@@ -745,6 +788,14 @@ class MatrixChannel:
                     )
                     return f"[Anhang: {filename} — zu groß]", None
 
+        event_id_val = getattr(event, "event_id", "?")
+        is_encrypted = enc_file is not None
+        logger.debug(
+            "MatrixChannel: download event={} encrypted={} url={}",
+            event_id_val,
+            is_encrypted,
+            mxc,
+        )
         logger.debug("MatrixChannel: downloading mxc={} filename={}", mxc, filename)
         resp = await self._client.download(server_name=server, media_id=media_id)
         if isinstance(resp, nio.DownloadError):
@@ -804,6 +855,12 @@ class MatrixChannel:
                 mxc,
                 mimetype,
             )
+            logger.debug(
+                "MatrixChannel: embed mxc={} embedded={} reason={}",
+                mxc,
+                False,
+                "not_embedded",
+            )
             return text, None
 
         # Encode-size estimate: 4 * ceil(raw / 3) + data-URL header length.
@@ -817,6 +874,12 @@ class MatrixChannel:
                 max_embed,
                 "exceeds_embed_limit",
             )
+            logger.debug(
+                "MatrixChannel: embed mxc={} embedded={} reason={}",
+                mxc,
+                False,
+                "size_exceeded",
+            )
             return text, None
 
         # Build multimodal content: text description + image_url block.
@@ -827,6 +890,12 @@ class MatrixChannel:
             {"type": "image_url", "image_url": {"url": data_url}},
         ]
         logger.debug("MatrixChannel: embedded mxc={} size={} mime={}", mxc, raw_bytes, mimetype)
+        logger.debug(
+            "MatrixChannel: embed mxc={} embedded={} reason={}",
+            mxc,
+            True,
+            "embedded",
+        )
         return text, multimodal_content
 
     # ── Typing keepalive ─────────────────────────────────────────────────────

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -1508,8 +1508,22 @@ class TestMatrixEncryptedMediaIntake:
         This is the pre-existing RED test (added in this branch) verifying the callback
         registration gap. The more complete version is
         test_registers_room_message_media_encrypted_media_and_bad_event_callbacks.
+
+        The implementation uses a single tuple registration (MEDIA_EVENT_FILTER) rather than
+        two individual registrations, so we flatten tuples when checking coverage.
         """
         from squidbot.adapters.channels.matrix import MatrixChannel
+
+        def _covered_types(call_args_list: list[Any]) -> set[type]:
+            """Flatten registered types from individual and tuple registrations."""
+            types: set[type] = set()
+            for c in call_args_list:
+                filter_arg = c.args[1]
+                if isinstance(filter_arg, tuple):
+                    types.update(filter_arg)
+                else:
+                    types.add(filter_arg)
+            return types
 
         config = _make_config(user_id="@bot:example.org")
         ch = MatrixChannel(config=config)
@@ -1525,10 +1539,10 @@ class TestMatrixEncryptedMediaIntake:
         ):
             await ch._connect()
 
-        registered_types = [call.args[1] for call in fake_client.add_event_callback.call_args_list]
+        covered = _covered_types(fake_client.add_event_callback.call_args_list)
 
-        assert nio.RoomMessageMedia in registered_types
-        assert nio.RoomEncryptedMedia in registered_types
+        assert nio.RoomMessageMedia in covered
+        assert nio.RoomEncryptedMedia in covered
 
     # ── BadEvent routing ──────────────────────────────────────────────────────
 

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -1804,6 +1804,119 @@ class TestMatrixEncryptedMediaIntake:
             f"Expected iv='bad_base64iv', got: {positional[3]!r}"
         )
 
+    async def test_debug_logs_include_event_class_and_media_shape(self) -> None:
+        """DEBUG log lines at five boundaries include required fields.
+
+        Captures loguru output at DEBUG level and asserts that:
+        - callback registration log contains 'MatrixChannel: registered callbacks classes='
+        - event classification log contains 'MatrixChannel: classify event=' with
+          class, msgtype, has_url, has_file_url, has_key_material fields
+        - policy decision log contains 'MatrixChannel: policy event=' with result and reason
+        - download/decrypt branch log contains 'MatrixChannel: download event=' with
+          encrypted and url fields
+        - embed decision log contains 'MatrixChannel: embed mxc=' with embedded and reason fields
+        """
+        import io
+
+        from loguru import logger
+
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        # Capture loguru output at DEBUG level
+        output = io.StringIO()
+        sink_id = logger.add(output, level="DEBUG", format="{message}")
+
+        try:
+            # --- Test classify + policy + download + embed logs via _handle_media ---
+            config = _make_config(group_policy="open")
+            ch = MatrixChannel(config=config)
+
+            image_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+            download_resp = MagicMock()
+            download_resp.body = image_bytes
+            download_resp.content_type = "image/jpeg"
+
+            ch._client = MagicMock()
+            ch._client.download = AsyncMock(return_value=download_resp)
+
+            event = MagicMock()
+            event.sender = "@alice:example.org"
+            event.room_id = "!room1:example.org"
+            event.event_id = "$diag1"
+            event.url = "mxc://example.org/diagmedia"
+            event.file = None
+            event.body = "photo.jpg"
+            event.source = {"content": {}}
+            event.server_timestamp = int(datetime.now().timestamp() * 1000)
+            info = MagicMock()
+            info.mimetype = "image/jpeg"
+            del info.size
+            event.info = info
+
+            await ch._handle_media(MagicMock(), event)
+
+            # --- Test callback registration log via _connect ---
+            config2 = _make_config(user_id="@bot:example.org")
+            ch2 = MatrixChannel(config=config2)
+            fake_cfg = MagicMock()
+            fake_client = MagicMock()
+            fake_client.add_event_callback = MagicMock()
+            fake_client.load_store = MagicMock()
+
+            with (
+                patch.object(ch2, "_crypto_store_path", return_value=("/tmp/store", True)),
+                patch(
+                    "squidbot.adapters.channels.matrix.nio.AsyncClientConfig",
+                    return_value=fake_cfg,
+                ),
+                patch(
+                    "squidbot.adapters.channels.matrix.nio.AsyncClient",
+                    return_value=fake_client,
+                ),
+            ):
+                await ch2._connect()
+
+            log_output = output.getvalue()
+
+            # Boundary 1: callback registration
+            assert "MatrixChannel: registered callbacks classes=" in log_output, (
+                f"Expected 'MatrixChannel: registered callbacks classes=' in log output.\n"
+                f"Got:\n{log_output}"
+            )
+
+            # Boundary 2: event classification
+            assert "MatrixChannel: classify event=" in log_output, (
+                f"Expected 'MatrixChannel: classify event=' in log output.\nGot:\n{log_output}"
+            )
+            assert "class=" in log_output
+            assert "msgtype=" in log_output
+            assert "has_url=" in log_output
+            assert "has_file_url=" in log_output
+            assert "has_key_material=" in log_output
+
+            # Boundary 3: policy decision
+            assert "MatrixChannel: policy event=" in log_output, (
+                f"Expected 'MatrixChannel: policy event=' in log output.\nGot:\n{log_output}"
+            )
+            assert "result=" in log_output
+            assert "reason=" in log_output
+
+            # Boundary 4: download/decrypt branch
+            assert "MatrixChannel: download event=" in log_output, (
+                f"Expected 'MatrixChannel: download event=' in log output.\nGot:\n{log_output}"
+            )
+            assert "encrypted=" in log_output
+            assert "url=" in log_output
+
+            # Boundary 5: embed decision
+            assert "MatrixChannel: embed mxc=" in log_output, (
+                f"Expected 'MatrixChannel: embed mxc=' in log output.\nGot:\n{log_output}"
+            )
+            assert "embedded=" in log_output
+
+        finally:
+            logger.remove(sink_id)
+
     async def test_malformed_declared_size_does_not_block_download(self) -> None:
         """When a BadEvent has a malformed info.size, the preflight guard is skipped
         and the download is still attempted through _handle_bad_event."""

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -1706,8 +1706,13 @@ class TestMatrixEncryptedMediaIntake:
         assert ch._queue.empty(), "Non-media BadEvent must not produce an InboundMessage"
 
     async def test_room_encrypted_media_decrypt_uses_key_k_and_hashes_sha256(self) -> None:
-        """_download_attachment passes positional strings to decrypt_attachment,
-        not a dict — guards against the pre-existing bug on matrix.py:773."""
+        """_download_attachment uses direct event.key/hashes/iv for RoomEncryptedMedia.
+
+        nio.RoomEncryptedMedia parses content.file.* into direct event attributes
+        (event.key, event.hashes, event.iv) — there is NO event.file attribute on
+        this class. The production code must use the direct-attribute path, not the
+        enc_file path, and must pass positional strings to decrypt_attachment (not a dict).
+        """
         from squidbot.adapters.channels.matrix import MatrixChannel
 
         config = _make_config()
@@ -1720,45 +1725,54 @@ class TestMatrixEncryptedMediaIntake:
             return_value=MagicMock(body=ciphertext, content_type="application/pdf")
         )
 
-        # nio.RoomEncryptedFile lacks room_id, info, and file attributes that
-        # _download_attachment reads (the event IS the encrypted wrapper; the production
-        # code detects E2EE via event.file, not by isinstance-checking the event type).
-        # A MagicMock lets us set exactly the attributes the current production code reads.
-        enc_file_event = MagicMock()
-        enc_file_event.sender = "@alice:example.org"
-        enc_file_event.room_id = "!room1:example.org"
-        enc_file_event.event_id = "$enc1"
-        enc_file_event.server_timestamp = 0
-        enc_file_event.body = "encrypted.pdf"
-        enc_file_event.source = {"content": {}}
-        enc_file_event.url = "mxc://example.com/enc"
-        enc_file_event.info = MagicMock()
-        enc_file_event.info.mimetype = "application/pdf"
-        # event.file triggers the E2EE decryption path in _download_attachment.
-        # Its attrs (key.k, hashes["sha256"], iv) are what the fixed code should read.
-        file_attr = MagicMock()
-        file_attr.url = "mxc://example.com/enc"
-        file_attr.key = MagicMock()
-        file_attr.key.k = "base64key"
-        file_attr.key.key_type = "oct"
-        file_attr.key.alg = "A256CTR"
-        file_attr.key.key_ops = ["encrypt", "decrypt"]
-        file_attr.key.ext = True
-        file_attr.iv = "base64iv"
-        file_attr.hashes = {"sha256": "base64hash"}
-        file_attr.v = "v2"
-        enc_file_event.file = file_attr
+        # Model the real RoomEncryptedMedia structure: key/hashes/iv are direct attributes
+        # on the event; event.file does NOT exist (not a dataclass field on RoomEncryptedMedia).
+        enc_media_event = MagicMock(
+            spec=[
+                "sender",
+                "room_id",
+                "event_id",
+                "server_timestamp",
+                "body",
+                "source",
+                "url",
+                "info",
+                "key",
+                "hashes",
+                "iv",
+            ]
+        )
+        enc_media_event.sender = "@alice:example.org"
+        enc_media_event.room_id = "!room1:example.org"
+        enc_media_event.event_id = "$enc1"
+        enc_media_event.server_timestamp = 0
+        enc_media_event.body = "encrypted.pdf"
+        # No content.file in source — key material lives on direct event attrs.
+        enc_media_event.source = {"content": {}}
+        enc_media_event.url = "mxc://example.com/enc"
+        enc_media_event.info = MagicMock()
+        enc_media_event.info.mimetype = "application/pdf"
+        # Direct attributes from nio RoomEncryptedMedia (parsed from content.file.*).
+        enc_media_event.key = {
+            "kty": "oct",
+            "alg": "A256CTR",
+            "k": "base64key",
+            "key_ops": ["encrypt", "decrypt"],
+            "ext": True,
+        }
+        enc_media_event.hashes = {"sha256": "base64hash"}
+        enc_media_event.iv = "base64iv"
 
         # Patch at source because matrix.py imports decrypt_attachment lazily inside the
         # function body: `from nio.crypto.attachments import decrypt_attachment`
         with patch("nio.crypto.attachments.decrypt_attachment") as mock_decrypt:
             mock_decrypt.return_value = b"decrypted content"
-            await ch._download_attachment(enc_file_event)
+            await ch._download_attachment(enc_media_event)
 
         mock_decrypt.assert_called_once()
         call_args = mock_decrypt.call_args
         # Must be called with positional strings: (ciphertext, key_str, hash_str, iv_str)
-        # NOT called with a dict as the second argument
+        # NOT called with a dict as the second argument (that was the pre-existing bug).
         positional = call_args.args
         n = len(positional)
         assert n == 4, (

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -1785,6 +1785,56 @@ class TestMatrixEncryptedMediaIntake:
         assert positional[2] == "base64hash", f"Expected hash='base64hash', got: {positional[2]!r}"
         assert positional[3] == "base64iv", f"Expected iv='base64iv', got: {positional[3]!r}"
 
+    async def test_room_encrypted_media_missing_key_material_warns_and_skips_decrypt(
+        self,
+    ) -> None:
+        """_download_attachment logs a warning and skips decrypt when direct E2EE attrs
+        are incomplete (e.g. iv is missing), leaving the raw ciphertext on disk."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config()
+        ch = MatrixChannel(config=config)
+
+        ciphertext = b"\x00" * 32
+        ch._client = MagicMock()
+        ch._client.download = AsyncMock(
+            return_value=MagicMock(body=ciphertext, content_type="application/octet-stream")
+        )
+
+        event = MagicMock(
+            spec=[
+                "sender",
+                "room_id",
+                "event_id",
+                "server_timestamp",
+                "body",
+                "source",
+                "url",
+                "info",
+                "key",
+                "hashes",
+                "iv",
+            ]
+        )
+        event.sender = "@alice:example.org"
+        event.room_id = "!room1:example.org"
+        event.event_id = "$enc2"
+        event.server_timestamp = 0
+        event.body = "mystery.bin"
+        event.source = {"content": {}}
+        event.url = "mxc://example.com/mystery"
+        event.info = MagicMock()
+        event.info.mimetype = "application/octet-stream"
+        # key is a dict (triggers has_direct_enc_attrs), but iv is missing → else branch.
+        event.key = {"kty": "oct", "alg": "A256CTR", "k": "somekey"}
+        event.hashes = {"sha256": "somehash"}
+        event.iv = None  # missing → decrypt skipped
+
+        with patch("nio.crypto.attachments.decrypt_attachment") as mock_decrypt:
+            await ch._download_attachment(event)
+
+        mock_decrypt.assert_not_called()
+
     async def test_bad_event_media_decrypt_uses_source_content_file_key_material(self) -> None:
         """_handle_bad_event extracts key material from source['content']['file']
         and passes positional strings to decrypt_attachment."""

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -1884,22 +1884,22 @@ class TestMatrixEncryptedMediaIntake:
                 f"Got:\n{log_output}"
             )
 
-            # Boundary 2: event classification
-            assert "MatrixChannel: classify event=" in log_output, (
-                f"Expected 'MatrixChannel: classify event=' in log output.\nGot:\n{log_output}"
-            )
-            assert "class=" in log_output
-            assert "msgtype=" in log_output
-            assert "has_url=" in log_output
-            assert "has_file_url=" in log_output
-            assert "has_key_material=" in log_output
+            # Boundary 2: event classification — assert all fields appear on one line
+            assert any(
+                "MatrixChannel: classify event=" in line
+                and " class=" in line
+                and " msgtype=" in line
+                and " has_url=" in line
+                and " has_file_url=" in line
+                and " has_key_material=" in line
+                for line in log_output.splitlines()
+            ), f"classify log line missing expected fields. Log output:\n{log_output}"
 
-            # Boundary 3: policy decision
-            assert "MatrixChannel: policy event=" in log_output, (
-                f"Expected 'MatrixChannel: policy event=' in log output.\nGot:\n{log_output}"
-            )
-            assert "result=" in log_output
-            assert "reason=" in log_output
+            # Boundary 3: policy decision — assert result= and reason= appear on one line
+            assert any(
+                "MatrixChannel: policy event=" in line and " result=" in line and " reason=" in line
+                for line in log_output.splitlines()
+            ), f"policy log line missing expected fields. Log output:\n{log_output}"
 
             # Boundary 4: download/decrypt branch
             assert "MatrixChannel: download event=" in log_output, (

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -851,6 +851,29 @@ class TestMatrixChannelE2ee:
         assert ch._e2ee_available is False
         assert ch._e2ee_degraded_reason == "StoreLoad:RuntimeError"
 
+    async def test_registers_room_message_and_room_encrypted_media_callbacks(self) -> None:
+        """_connect() registers media callbacks for plain and encrypted media events."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(user_id="@bot:example.org")
+        ch = MatrixChannel(config=config)
+        fake_cfg = MagicMock()
+        fake_client = MagicMock()
+        fake_client.add_event_callback = MagicMock()
+        fake_client.load_store = MagicMock()
+
+        with (
+            patch.object(ch, "_crypto_store_path", return_value=("/tmp/store", True)),
+            patch("squidbot.adapters.channels.matrix.nio.AsyncClientConfig", return_value=fake_cfg),
+            patch("squidbot.adapters.channels.matrix.nio.AsyncClient", return_value=fake_client),
+        ):
+            await ch._connect()
+
+        registered_types = [call.args[1] for call in fake_client.add_event_callback.call_args_list]
+
+        assert nio.RoomMessageMedia in registered_types
+        assert nio.RoomEncryptedMedia in registered_types
+
     async def test_logs_encrypted_unknown_event_details(self) -> None:
         from squidbot.adapters.channels.matrix import MatrixChannel
 
@@ -1117,6 +1140,58 @@ class TestMatrixInboundGuardrails:
         resp.body = body
         resp.content_type = mime
         return resp
+
+    async def test_encrypted_file_with_content_file_url_is_processed(self) -> None:
+        """Encrypted m.file with content.file.url is downloaded and processed."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="open")
+        ch = MatrixChannel(config=config)
+        ch._client = MagicMock()
+        ch._client.download = AsyncMock(
+            return_value=self._make_download_resp(b"%PDF-1.7 encrypted", "application/pdf")
+        )
+
+        event = MagicMock()
+        event.url = ""
+        event.file = None
+        event.body = "secret.pdf"
+        event.source = {
+            "content": {
+                "msgtype": "m.file",
+                "file": {
+                    "url": "mxc://example.org/encrypted_media_123",
+                },
+            }
+        }
+        event.info = MagicMock()
+        event.info.mimetype = "application/pdf"
+
+        text, multimodal = await ch._download_attachment(event)
+
+        ch._client.download.assert_awaited_once_with(
+            server_name="example.org",
+            media_id="encrypted_media_123",
+        )
+        assert "secret.pdf" in text
+        assert multimodal is None
+
+    async def test_media_event_not_dropped_only_due_to_filename_without_mention(self) -> None:
+        """Mention policy should not drop media events solely because filename lacks mention."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="mention")
+        ch = MatrixChannel(config=config)
+        ch._client = MagicMock()
+        ch._download_attachment = AsyncMock(return_value=("[Anhang: invoice.pdf]", None))
+
+        event = self._make_media_event(filename="invoice.pdf", mime="application/pdf")
+        event.source = {"content": {"msgtype": "m.file"}}
+
+        await ch._handle_media(MagicMock(), event)
+
+        assert not ch._queue.empty()
+        ch._download_attachment.assert_awaited_once_with(event)
 
     async def test_jpeg_under_embed_limit_produces_multimodal_content(self, tmp_path: Path) -> None:
         """JPEG under embed limit embeds as Base64 image_url block."""
@@ -1426,4 +1501,327 @@ class TestMatrixInboundGuardrails:
             "!group:example.org",
             "@owner:example.org",
             boom,
+        )
+
+
+class TestMatrixEncryptedMediaIntake:
+    """Encrypted media intake: RoomEncryptedMedia callbacks, BadEvent routing, and decryption."""
+
+    def _make_bad_event_with_media(
+        self,
+        msgtype: str = "m.file",
+        filename: str = "doc.pdf",
+        mxc: str = "mxc://example.com/abc",
+        key_k: str = "base64key",
+        iv: str = "base64iv",
+        sha256: str = "base64hash",
+    ) -> nio.BadEvent:
+        """Build a nio.BadEvent whose content has the encrypted-file shape."""
+        source: dict[str, Any] = {
+            "sender": "@alice:example.org",
+            "event_id": "$bad1",
+            "origin_server_ts": 0,
+            "room_id": "!room1:example.org",
+            "type": "m.room.message",
+            "unsigned": {},
+            "content": {
+                "msgtype": msgtype,
+                "body": filename,
+                "file": {
+                    "url": mxc,
+                    "key": {
+                        "k": key_k,
+                        "kty": "oct",
+                        "alg": "A256CTR",
+                        "key_ops": ["encrypt", "decrypt"],
+                        "ext": True,
+                    },
+                    "iv": iv,
+                    "hashes": {"sha256": sha256},
+                },
+            },
+        }
+        return nio.BadEvent(
+            source=source,
+            event_id="$bad1",
+            sender="@alice:example.org",
+            server_timestamp=0,
+            type="m.room.message",
+        )
+
+    async def test_registers_room_message_media_encrypted_media_and_bad_event_callbacks(
+        self,
+    ) -> None:
+        """_connect() registers _handle_media for both RoomMessageMedia and RoomEncryptedMedia,
+        and _handle_bad_event for BadEvent."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(user_id="@bot:example.org")
+        ch = MatrixChannel(config=config)
+        fake_cfg = MagicMock()
+        fake_client = MagicMock()
+        fake_client.add_event_callback = MagicMock()
+        fake_client.load_store = MagicMock()
+
+        with (
+            patch.object(ch, "_crypto_store_path", return_value=("/tmp/store", True)),
+            patch("squidbot.adapters.channels.matrix.nio.AsyncClientConfig", return_value=fake_cfg),
+            patch("squidbot.adapters.channels.matrix.nio.AsyncClient", return_value=fake_client),
+        ):
+            await ch._connect()
+
+        calls = fake_client.add_event_callback.call_args_list
+
+        # _handle_media must be registered for (RoomMessageMedia, RoomEncryptedMedia) as a tuple
+        assert any(
+            c.args[0] == ch._handle_media
+            and isinstance(c.args[1], tuple)
+            and set(c.args[1]) == {nio.RoomMessageMedia, nio.RoomEncryptedMedia}
+            for c in calls
+        ), (
+            "_handle_media must be registered with (RoomMessageMedia, RoomEncryptedMedia) tuple. "
+            f"Actual calls: {calls}"
+        )
+
+        # _handle_bad_event must be registered for BadEvent
+        assert any(
+            c.args[0] == ch._handle_bad_event and c.args[1] is nio.BadEvent for c in calls
+        ), f"_handle_bad_event must be registered for nio.BadEvent. Actual calls: {calls}"
+
+    async def test_bad_event_with_media_shape_routes_to_media_pipeline(self) -> None:
+        """A BadEvent whose content has the encrypted-file shape is routed to the media pipeline."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="open")
+        ch = MatrixChannel(config=config)
+        ch._client = MagicMock()
+        ch._download_attachment = AsyncMock(
+            return_value=("[Anhang: doc.pdf (application/pdf)] → /tmp/abc.pdf", None)
+        )
+
+        room = MagicMock()
+        room.room_id = "!room1:example.org"
+        event = self._make_bad_event_with_media(msgtype="m.file", filename="doc.pdf")
+
+        await ch._handle_bad_event(room, event)
+
+        assert not ch._queue.empty(), "Expected an InboundMessage to be queued for media BadEvent"
+        msg = ch._queue.get_nowait()
+        assert msg.session.sender_id == "@alice:example.org"
+
+    async def test_bad_event_without_media_shape_is_ignored(self) -> None:
+        """A BadEvent whose content is a plain text event (no 'file' key) is ignored."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="open")
+        ch = MatrixChannel(config=config)
+
+        source: dict[str, Any] = {
+            "sender": "@alice:example.org",
+            "event_id": "$bad2",
+            "origin_server_ts": 0,
+            "room_id": "!room1:example.org",
+            "type": "m.room.message",
+            "unsigned": {},
+            "content": {"msgtype": "m.text", "body": "hello"},
+        }
+        event = nio.BadEvent(
+            source=source,
+            event_id="$bad2",
+            sender="@alice:example.org",
+            server_timestamp=0,
+            type="m.room.message",
+        )
+
+        room = MagicMock()
+        room.room_id = "!room1:example.org"
+
+        await ch._handle_bad_event(room, event)
+
+        assert ch._queue.empty(), "Non-media BadEvent must not produce an InboundMessage"
+
+    async def test_room_encrypted_media_decrypt_uses_key_k_and_hashes_sha256(self) -> None:
+        """_download_attachment passes positional strings to decrypt_attachment,
+        not a dict — guards against the pre-existing bug on matrix.py:773."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config()
+        ch = MatrixChannel(config=config)
+
+        ciphertext = b"\x00" * 32
+        enc_file = nio.RoomEncryptedFile(
+            source={
+                "sender": "@alice:example.org",
+                "event_id": "$enc1",
+                "origin_server_ts": 0,
+                "room_id": "!room1:example.org",
+                "type": "m.room.message",
+                "unsigned": {},
+                "content": {},
+            },
+            url="mxc://example.com/enc",
+            body="encrypted.pdf",
+            key={
+                "k": "base64key",
+                "kty": "oct",
+                "alg": "A256CTR",
+                "key_ops": ["encrypt", "decrypt"],
+                "ext": True,
+            },
+            hashes={"sha256": "base64hash"},
+            iv="base64iv",
+            mimetype="application/pdf",
+        )
+
+        ch._client = MagicMock()
+        ch._client.download = AsyncMock(
+            return_value=MagicMock(body=ciphertext, content_type="application/pdf")
+        )
+        # enc_file has no room_id attr, set it via source mock pattern
+        enc_file_event = MagicMock()
+        enc_file_event.sender = "@alice:example.org"
+        enc_file_event.room_id = "!room1:example.org"
+        enc_file_event.event_id = "$enc1"
+        enc_file_event.server_timestamp = 0
+        enc_file_event.body = "encrypted.pdf"
+        enc_file_event.source = {"content": {}}
+        enc_file_event.url = "mxc://example.com/enc"
+        enc_file_event.file = None
+        enc_file_event.info = MagicMock()
+        enc_file_event.info.mimetype = "application/pdf"
+        # Attach enc_file attributes for E2EE detection:
+        # In the production code, event.file would be the enc_file; simulate this
+        # by providing a file attribute with enc_file-like attrs
+        file_attr = MagicMock()
+        file_attr.url = "mxc://example.com/enc"
+        file_attr.key = MagicMock()
+        file_attr.key.k = "base64key"
+        file_attr.key.key_type = "oct"
+        file_attr.key.alg = "A256CTR"
+        file_attr.key.key_ops = ["encrypt", "decrypt"]
+        file_attr.key.ext = True
+        file_attr.iv = "base64iv"
+        file_attr.hashes = {"sha256": "base64hash"}
+        file_attr.v = "v2"
+        enc_file_event.file = file_attr
+
+        with patch("nio.crypto.attachments.decrypt_attachment") as mock_decrypt:
+            mock_decrypt.return_value = b"decrypted content"
+            await ch._download_attachment(enc_file_event)
+
+        mock_decrypt.assert_called_once()
+        call_args = mock_decrypt.call_args
+        # Must be called with positional strings: (ciphertext, key_str, hash_str, iv_str)
+        # NOT called with a dict as the second argument
+        positional = call_args.args
+        assert len(positional) == 4, (
+            f"Expected 4 positional args (ciphertext, key, hash, iv), got {len(positional)}: {positional}"
+        )
+        assert not isinstance(positional[1], dict), (
+            f"decrypt_attachment arg[1] (key) must be a string, not a dict. Got: {positional[1]!r}"
+        )
+        assert positional[1] == "base64key", f"Expected key='base64key', got: {positional[1]!r}"
+        assert positional[2] == "base64hash", f"Expected hash='base64hash', got: {positional[2]!r}"
+        assert positional[3] == "base64iv", f"Expected iv='base64iv', got: {positional[3]!r}"
+
+    async def test_bad_event_media_decrypt_uses_source_content_file_key_material(self) -> None:
+        """_handle_bad_event extracts key material from source['content']['file']
+        and passes positional strings to decrypt_attachment."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="open")
+        ch = MatrixChannel(config=config)
+        ciphertext = b"\x00" * 32
+
+        event = self._make_bad_event_with_media(
+            mxc="mxc://example.com/badsec",
+            key_k="bad_base64key",
+            iv="bad_base64iv",
+            sha256="bad_base64hash",
+        )
+
+        room = MagicMock()
+        room.room_id = "!room1:example.org"
+
+        ch._client = MagicMock()
+        ch._client.download = AsyncMock(
+            return_value=MagicMock(body=ciphertext, content_type="application/pdf")
+        )
+
+        with patch("nio.crypto.attachments.decrypt_attachment") as mock_decrypt:
+            mock_decrypt.return_value = b"decrypted pdf content"
+            await ch._handle_bad_event(room, event)
+
+        mock_decrypt.assert_called_once()
+        call_args = mock_decrypt.call_args
+        positional = call_args.args
+        assert len(positional) == 4, (
+            f"Expected 4 positional args (ciphertext, key, hash, iv), got {len(positional)}: {positional}"
+        )
+        assert positional[1] == "bad_base64key", (
+            f"Expected key='bad_base64key', got: {positional[1]!r}"
+        )
+        assert positional[2] == "bad_base64hash", (
+            f"Expected hash='bad_base64hash', got: {positional[2]!r}"
+        )
+        assert positional[3] == "bad_base64iv", (
+            f"Expected iv='bad_base64iv', got: {positional[3]!r}"
+        )
+
+    async def test_malformed_declared_size_does_not_block_download(self) -> None:
+        """When a BadEvent has a malformed info.size, the preflight guard is skipped
+        and the download is still attempted through _handle_bad_event."""
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="open")
+        ch = MatrixChannel(config=config)
+        ch._client = MagicMock()
+        download_mock = AsyncMock(
+            return_value=MagicMock(body=b"some file content", content_type="application/pdf")
+        )
+        ch._client.download = download_mock
+
+        # BadEvent whose content has file shape but malformed size in info
+        source: dict[str, Any] = {
+            "sender": "@alice:example.org",
+            "event_id": "$bad_size",
+            "origin_server_ts": 0,
+            "room_id": "!room1:example.org",
+            "type": "m.room.message",
+            "unsigned": {},
+            "content": {
+                "msgtype": "m.file",
+                "body": "doc.pdf",
+                "info": {"size": "not-a-number", "mimetype": "application/pdf"},
+                "file": {
+                    "url": "mxc://example.org/badsize123",
+                    "key": {
+                        "k": "base64key",
+                        "kty": "oct",
+                        "alg": "A256CTR",
+                        "key_ops": ["encrypt", "decrypt"],
+                        "ext": True,
+                    },
+                    "iv": "base64iv",
+                    "hashes": {"sha256": "base64hash"},
+                },
+            },
+        }
+        event = nio.BadEvent(
+            source=source,
+            event_id="$bad_size",
+            sender="@alice:example.org",
+            server_timestamp=0,
+            type="m.room.message",
+        )
+
+        room = MagicMock()
+        room.room_id = "!room1:example.org"
+
+        with patch("nio.crypto.attachments.decrypt_attachment", return_value=b"decrypted"):
+            await ch._handle_bad_event(room, event)
+
+        (
+            download_mock.assert_awaited_once(),
+            ("Download must be attempted even when declared size is malformed"),
         )

--- a/tests/adapters/channels/test_matrix.py
+++ b/tests/adapters/channels/test_matrix.py
@@ -851,29 +851,6 @@ class TestMatrixChannelE2ee:
         assert ch._e2ee_available is False
         assert ch._e2ee_degraded_reason == "StoreLoad:RuntimeError"
 
-    async def test_registers_room_message_and_room_encrypted_media_callbacks(self) -> None:
-        """_connect() registers media callbacks for plain and encrypted media events."""
-        from squidbot.adapters.channels.matrix import MatrixChannel
-
-        config = _make_config(user_id="@bot:example.org")
-        ch = MatrixChannel(config=config)
-        fake_cfg = MagicMock()
-        fake_client = MagicMock()
-        fake_client.add_event_callback = MagicMock()
-        fake_client.load_store = MagicMock()
-
-        with (
-            patch.object(ch, "_crypto_store_path", return_value=("/tmp/store", True)),
-            patch("squidbot.adapters.channels.matrix.nio.AsyncClientConfig", return_value=fake_cfg),
-            patch("squidbot.adapters.channels.matrix.nio.AsyncClient", return_value=fake_client),
-        ):
-            await ch._connect()
-
-        registered_types = [call.args[1] for call in fake_client.add_event_callback.call_args_list]
-
-        assert nio.RoomMessageMedia in registered_types
-        assert nio.RoomEncryptedMedia in registered_types
-
     async def test_logs_encrypted_unknown_event_details(self) -> None:
         from squidbot.adapters.channels.matrix import MatrixChannel
 
@@ -1140,58 +1117,6 @@ class TestMatrixInboundGuardrails:
         resp.body = body
         resp.content_type = mime
         return resp
-
-    async def test_encrypted_file_with_content_file_url_is_processed(self) -> None:
-        """Encrypted m.file with content.file.url is downloaded and processed."""
-        from squidbot.adapters.channels.matrix import MatrixChannel
-
-        config = _make_config(group_policy="open")
-        ch = MatrixChannel(config=config)
-        ch._client = MagicMock()
-        ch._client.download = AsyncMock(
-            return_value=self._make_download_resp(b"%PDF-1.7 encrypted", "application/pdf")
-        )
-
-        event = MagicMock()
-        event.url = ""
-        event.file = None
-        event.body = "secret.pdf"
-        event.source = {
-            "content": {
-                "msgtype": "m.file",
-                "file": {
-                    "url": "mxc://example.org/encrypted_media_123",
-                },
-            }
-        }
-        event.info = MagicMock()
-        event.info.mimetype = "application/pdf"
-
-        text, multimodal = await ch._download_attachment(event)
-
-        ch._client.download.assert_awaited_once_with(
-            server_name="example.org",
-            media_id="encrypted_media_123",
-        )
-        assert "secret.pdf" in text
-        assert multimodal is None
-
-    async def test_media_event_not_dropped_only_due_to_filename_without_mention(self) -> None:
-        """Mention policy should not drop media events solely because filename lacks mention."""
-        from squidbot.adapters.channels.matrix import MatrixChannel
-
-        config = _make_config(group_policy="mention")
-        ch = MatrixChannel(config=config)
-        ch._client = MagicMock()
-        ch._download_attachment = AsyncMock(return_value=("[Anhang: invoice.pdf]", None))
-
-        event = self._make_media_event(filename="invoice.pdf", mime="application/pdf")
-        event.source = {"content": {"msgtype": "m.file"}}
-
-        await ch._handle_media(MagicMock(), event)
-
-        assert not ch._queue.empty()
-        ch._download_attachment.assert_awaited_once_with(event)
 
     async def test_jpeg_under_embed_limit_produces_multimodal_content(self, tmp_path: Path) -> None:
         """JPEG under embed limit embeds as Base64 image_url block."""
@@ -1549,6 +1474,130 @@ class TestMatrixEncryptedMediaIntake:
             type="m.room.message",
         )
 
+    def _make_plain_media_event(
+        self,
+        mxc: str = "mxc://example.org/abc123",
+        filename: str = "photo.jpg",
+        mime: str = "image/jpeg",
+        declared_size: int | None = None,
+    ) -> MagicMock:
+        """Build a minimal plain (non-encrypted) media event mock."""
+        event = MagicMock()
+        event.sender = "@alice:example.org"
+        event.room_id = "!room1:example.org"
+        event.event_id = "$media1"
+        event.url = mxc
+        event.file = None
+        event.body = filename
+        event.source = {"content": {}}
+        event.server_timestamp = int(datetime.now().timestamp() * 1000)
+        info = MagicMock()
+        info.mimetype = mime
+        if declared_size is not None:
+            info.size = declared_size
+        else:
+            del info.size
+        event.info = info
+        return event
+
+    # ── Callback registration ─────────────────────────────────────────────────
+
+    async def test_registers_room_message_and_room_encrypted_media_callbacks(self) -> None:
+        """_connect() registers _handle_media for both RoomMessageMedia and RoomEncryptedMedia.
+
+        This is the pre-existing RED test (added in this branch) verifying the callback
+        registration gap. The more complete version is
+        test_registers_room_message_media_encrypted_media_and_bad_event_callbacks.
+        """
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(user_id="@bot:example.org")
+        ch = MatrixChannel(config=config)
+        fake_cfg = MagicMock()
+        fake_client = MagicMock()
+        fake_client.add_event_callback = MagicMock()
+        fake_client.load_store = MagicMock()
+
+        with (
+            patch.object(ch, "_crypto_store_path", return_value=("/tmp/store", True)),
+            patch("squidbot.adapters.channels.matrix.nio.AsyncClientConfig", return_value=fake_cfg),
+            patch("squidbot.adapters.channels.matrix.nio.AsyncClient", return_value=fake_client),
+        ):
+            await ch._connect()
+
+        registered_types = [call.args[1] for call in fake_client.add_event_callback.call_args_list]
+
+        assert nio.RoomMessageMedia in registered_types
+        assert nio.RoomEncryptedMedia in registered_types
+
+    # ── BadEvent routing ──────────────────────────────────────────────────────
+
+    async def test_encrypted_file_with_content_file_url_is_processed(self) -> None:
+        """Encrypted m.file with content.file.url is downloaded via _download_attachment.
+
+        Verifies the BadEvent-routing path: when nio returns BadEvent for an event
+        with content.file.url shape, _handle_bad_event must extract the mxc URL from
+        source['content']['file']['url'] and pass it through the download pipeline.
+        """
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="open")
+        ch = MatrixChannel(config=config)
+        ch._client = MagicMock()
+        download_resp = MagicMock()
+        download_resp.body = b"%PDF-1.7 encrypted"
+        download_resp.content_type = "application/pdf"
+        ch._client.download = AsyncMock(return_value=download_resp)
+
+        event = MagicMock()
+        event.url = ""
+        event.file = None
+        event.body = "secret.pdf"
+        event.source = {
+            "content": {
+                "msgtype": "m.file",
+                "file": {
+                    "url": "mxc://example.org/encrypted_media_123",
+                },
+            }
+        }
+        event.info = MagicMock()
+        event.info.mimetype = "application/pdf"
+
+        text, multimodal = await ch._download_attachment(event)
+
+        ch._client.download.assert_awaited_once_with(
+            server_name="example.org",
+            media_id="encrypted_media_123",
+        )
+        assert "secret.pdf" in text
+        assert multimodal is None
+
+    async def test_media_event_not_dropped_only_due_to_filename_without_mention(self) -> None:
+        """Mention policy must not drop media events because the filename lacks a bot mention.
+
+        Media event bodies are filenames, not user text. The mention check in _accept_event
+        compares event.body against config.user_id — for media events this produces false
+        negatives. _handle_media (and _handle_bad_event) must bypass this check or use
+        a separate acceptance path for media msgtypes.
+        """
+        from squidbot.adapters.channels.matrix import MatrixChannel
+
+        config = _make_config(group_policy="mention")
+        ch = MatrixChannel(config=config)
+        ch._client = MagicMock()
+        ch._download_attachment = AsyncMock(return_value=("[Anhang: invoice.pdf]", None))
+
+        event = self._make_plain_media_event(filename="invoice.pdf", mime="application/pdf")
+        event.source = {"content": {"msgtype": "m.file"}}
+
+        await ch._handle_media(MagicMock(), event)
+
+        assert not ch._queue.empty()
+        ch._download_attachment.assert_awaited_once_with(event)
+
+    # ── Full encrypted-media callback registration ────────────────────────────
+
     async def test_registers_room_message_media_encrypted_media_and_bad_event_callbacks(
         self,
     ) -> None:
@@ -1608,6 +1657,8 @@ class TestMatrixEncryptedMediaIntake:
         assert not ch._queue.empty(), "Expected an InboundMessage to be queued for media BadEvent"
         msg = ch._queue.get_nowait()
         assert msg.session.sender_id == "@alice:example.org"
+        # _download_attachment must be called with just the event (same as _handle_media)
+        ch._download_attachment.assert_awaited_once_with(event)
 
     async def test_bad_event_without_media_shape_is_ignored(self) -> None:
         """A BadEvent whose content is a plain text event (no 'file' key) is ignored."""
@@ -1649,35 +1700,16 @@ class TestMatrixEncryptedMediaIntake:
         ch = MatrixChannel(config=config)
 
         ciphertext = b"\x00" * 32
-        enc_file = nio.RoomEncryptedFile(
-            source={
-                "sender": "@alice:example.org",
-                "event_id": "$enc1",
-                "origin_server_ts": 0,
-                "room_id": "!room1:example.org",
-                "type": "m.room.message",
-                "unsigned": {},
-                "content": {},
-            },
-            url="mxc://example.com/enc",
-            body="encrypted.pdf",
-            key={
-                "k": "base64key",
-                "kty": "oct",
-                "alg": "A256CTR",
-                "key_ops": ["encrypt", "decrypt"],
-                "ext": True,
-            },
-            hashes={"sha256": "base64hash"},
-            iv="base64iv",
-            mimetype="application/pdf",
-        )
 
         ch._client = MagicMock()
         ch._client.download = AsyncMock(
             return_value=MagicMock(body=ciphertext, content_type="application/pdf")
         )
-        # enc_file has no room_id attr, set it via source mock pattern
+
+        # nio.RoomEncryptedFile lacks room_id, info, and file attributes that
+        # _download_attachment reads (the event IS the encrypted wrapper; the production
+        # code detects E2EE via event.file, not by isinstance-checking the event type).
+        # A MagicMock lets us set exactly the attributes the current production code reads.
         enc_file_event = MagicMock()
         enc_file_event.sender = "@alice:example.org"
         enc_file_event.room_id = "!room1:example.org"
@@ -1686,12 +1718,10 @@ class TestMatrixEncryptedMediaIntake:
         enc_file_event.body = "encrypted.pdf"
         enc_file_event.source = {"content": {}}
         enc_file_event.url = "mxc://example.com/enc"
-        enc_file_event.file = None
         enc_file_event.info = MagicMock()
         enc_file_event.info.mimetype = "application/pdf"
-        # Attach enc_file attributes for E2EE detection:
-        # In the production code, event.file would be the enc_file; simulate this
-        # by providing a file attribute with enc_file-like attrs
+        # event.file triggers the E2EE decryption path in _download_attachment.
+        # Its attrs (key.k, hashes["sha256"], iv) are what the fixed code should read.
         file_attr = MagicMock()
         file_attr.url = "mxc://example.com/enc"
         file_attr.key = MagicMock()
@@ -1705,6 +1735,8 @@ class TestMatrixEncryptedMediaIntake:
         file_attr.v = "v2"
         enc_file_event.file = file_attr
 
+        # Patch at source because matrix.py imports decrypt_attachment lazily inside the
+        # function body: `from nio.crypto.attachments import decrypt_attachment`
         with patch("nio.crypto.attachments.decrypt_attachment") as mock_decrypt:
             mock_decrypt.return_value = b"decrypted content"
             await ch._download_attachment(enc_file_event)
@@ -1714,8 +1746,9 @@ class TestMatrixEncryptedMediaIntake:
         # Must be called with positional strings: (ciphertext, key_str, hash_str, iv_str)
         # NOT called with a dict as the second argument
         positional = call_args.args
-        assert len(positional) == 4, (
-            f"Expected 4 positional args (ciphertext, key, hash, iv), got {len(positional)}: {positional}"
+        n = len(positional)
+        assert n == 4, (
+            f"Expected 4 positional args (ciphertext, key, hash, iv), got {n}: {positional}"
         )
         assert not isinstance(positional[1], dict), (
             f"decrypt_attachment arg[1] (key) must be a string, not a dict. Got: {positional[1]!r}"
@@ -1748,6 +1781,8 @@ class TestMatrixEncryptedMediaIntake:
             return_value=MagicMock(body=ciphertext, content_type="application/pdf")
         )
 
+        # Patch at source because matrix.py imports decrypt_attachment lazily inside the
+        # function body: `from nio.crypto.attachments import decrypt_attachment`
         with patch("nio.crypto.attachments.decrypt_attachment") as mock_decrypt:
             mock_decrypt.return_value = b"decrypted pdf content"
             await ch._handle_bad_event(room, event)
@@ -1755,8 +1790,9 @@ class TestMatrixEncryptedMediaIntake:
         mock_decrypt.assert_called_once()
         call_args = mock_decrypt.call_args
         positional = call_args.args
-        assert len(positional) == 4, (
-            f"Expected 4 positional args (ciphertext, key, hash, iv), got {len(positional)}: {positional}"
+        n = len(positional)
+        assert n == 4, (
+            f"Expected 4 positional args (ciphertext, key, hash, iv), got {n}: {positional}"
         )
         assert positional[1] == "bad_base64key", (
             f"Expected key='bad_base64key', got: {positional[1]!r}"
@@ -1818,10 +1854,10 @@ class TestMatrixEncryptedMediaIntake:
         room = MagicMock()
         room.room_id = "!room1:example.org"
 
+        # Patch at source because matrix.py imports decrypt_attachment lazily inside the
+        # function body: `from nio.crypto.attachments import decrypt_attachment`
         with patch("nio.crypto.attachments.decrypt_attachment", return_value=b"decrypted"):
             await ch._handle_bad_event(room, event)
 
-        (
-            download_mock.assert_awaited_once(),
-            ("Download must be attempted even when declared size is malformed"),
-        )
+        # Download must be attempted even when declared size is malformed
+        download_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Register a single `(RoomMessageMedia, RoomEncryptedMedia)` tuple callback so E2EE-room encrypted file events are no longer silently dropped
- Fix pre-existing bug where `decrypt_attachment` was called with a dict instead of four positional strings (`key["k"]`, `hashes["sha256"]`, `iv`)
- Add `BadEvent` fallback handler for clients that send `m.room.message` with an `content.file` field (non-E2EE shape); routes through the same media pipeline
- Extract shared `_enqueue_media_message` helper to eliminate callback duplication
- Skip the body-based mention check for all four media msgtypes (`m.image`, `m.file`, `m.audio`, `m.video`) so media events are never dropped by the mention policy
- Add 5 greppable `logger.debug` boundaries (`registered callbacks`, `classify`, `policy`, `download`, `embed`) for diagnostic tracing
- Add 9 new TDD tests in `TestMatrixEncryptedMediaIntake` covering all the above paths; 527/527 tests pass

## Design

See `docs/plans/2026-03-01-matrix-encrypted-media-intake-design.md` for full architecture, event-shape taxonomy, and risk assessment.

## Test Plan

- [x] `uv run pytest` → 527 passed
- [x] `uv run mypy squidbot/` → no errors
- [x] `uv run ruff check .` → no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design and implementation plans describing a unified encrypted-media intake workflow, safety/mention-policy guardrails, diagnostic logging, testing strategy, and risk considerations.
* **New Features**
  * Encrypted and unencrypted media uploads are routed through a common intake path for consistent handling.
* **Bug Fixes / Tests**
  * Fixed decryption argument usage, improved robustness for encrypted uploads (download/decrypt fallbacks), and added extensive tests and diagnostic logging for routing, decryption, embedding, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->