### PR TITLE
fix: support single-line $$...$$ block math syntax

### DIFF
--- a/squidbot/adapters/channels/matrix_markdown.py
+++ b/squidbot/adapters/channels/matrix_markdown.py
@@ -30,8 +30,13 @@ __all__ = ["plugin_mx_math", "plugin_mx_spoiler", "plugin_mx_block_spoiler", "sa
 # Math plugin
 # ---------------------------------------------------------------------------
 
-# Reuse the same patterns as mistune's built-in math plugin.
-_BLOCK_MATH_PATTERN = r"^ {0,3}\$\$[ \t]*\n(?P<math_text>[\s\S]+?)\n\$\$[ \t]*$"
+# Block math: multi-line form  $$\ncontent\n$$  or single-line form  $$content$$
+# The single-line alternative uses a separate named group (math_text_s) because
+# Python regex does not allow the same group name in two alternatives.
+_BLOCK_MATH_PATTERN = (
+    r"^ {0,3}\$\$[ \t]*\n(?P<math_text>[\s\S]+?)\n\$\$[ \t]*$"
+    r"|^ {0,3}\$\$[ \t]*(?P<math_text_s>[^\n$][^\n]*?)[ \t]*\$\$[ \t]*$"
+)
 _INLINE_MATH_PATTERN = r"\$(?!\s)(?P<math_text>.+?)(?!\s)\$"
 
 
@@ -51,7 +56,8 @@ def plugin_mx_math(md: Markdown) -> None:
     """
 
     def _parse_block_math(block: BlockParser, m: Any, state: BlockState) -> int:
-        state.append_token({"type": "mx_block_math", "raw": m.group("math_text")})
+        math_text: str = m.group("math_text") or m.group("math_text_s") or ""
+        state.append_token({"type": "mx_block_math", "raw": math_text})
         return int(m.end()) + 1
 
     def _parse_inline_math(inline: InlineParser, m: Any, state: InlineState) -> int:

--- a/tests/adapters/channels/test_markdown_plugins.py
+++ b/tests/adapters/channels/test_markdown_plugins.py
@@ -395,6 +395,23 @@ class TestMatrixMathPlugin:
         assert "data-mx-maths=" in result
         assert "a^2" in result
 
+    def test_block_math_single_line_renders_div(self) -> None:
+        """Single-line $$...$$ renders to <div data-mx-maths>, not <span>."""
+        from squidbot.adapters.channels.matrix import _render_markdown
+
+        result = _render_markdown("$$a^2 + b^2 = c^2$$")
+        assert '<div data-mx-maths="a^2 + b^2 = c^2">' in result
+        assert (
+            "<span" not in result or "data-mx-maths" not in result.split("<span")[1].split(">")[0]
+        )
+
+    def test_block_math_single_line_no_stray_dollar(self) -> None:
+        """Single-line $$...$$ leaves no stray $ in output."""
+        from squidbot.adapters.channels.matrix import _render_markdown
+
+        result = _render_markdown("$$E=mc^2$$")
+        assert "$" not in result
+
     def test_math_does_not_appear_in_email(self) -> None:
         """Email _md does NOT render data-mx-maths (Matrix-only plugin)."""
         from squidbot.adapters.channels.email import _md


### PR DESCRIPTION
## Summary

- `_BLOCK_MATH_PATTERN` only matched multi-line `$$\ncontent\n$$` form
- Single-line `$$content$$` fell through to the inline parser, incorrectly matching `$content$` and leaving a stray `$` in the output
- Fix: add a second alternative to the pattern for single-line block math using a separate named group (`math_text_s`)

## Root cause

```python
# Before — mandatory \n after $$:
r"^ {0,3}\$\$[ \t]*\n(?P<math_text>[\s\S]+?)\n\$\$[ \t]*$"

# After — also handles $$content$$ on one line:
r"^ {0,3}\$\$[ \t]*\n(?P<math_text>[\s\S]+?)\n\$\$[ \t]*$"
r"|^ {0,3}\$\$[ \t]*(?P<math_text_s>[^\n$][^\n]*?)[ \t]*\$\$[ \t]*$"
```

## Test Plan
- 2 new regression tests: `test_block_math_single_line_renders_div`, `test_block_math_single_line_no_stray_dollar`
- All 8 math plugin tests pass, full suite 596/596 pass (12 pre-existing failures in unrelated `test_send_attachment.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for single-line block math in Markdown. Mathematical expressions can now be written using the $$....$$ syntax on a single line, providing a more concise alternative to multi-line math notation. Single-line block math expressions render correctly as dedicated math blocks with proper formatting and no rendering artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->