### PR TITLE
fix: bootstrap HEARTBEAT.md during onboarding

### DIFF
--- a/squidbot/cli/main.py
+++ b/squidbot/cli/main.py
@@ -94,6 +94,7 @@ BOOTSTRAP_FILES_ONBOARD: list[str] = [
     "SOUL.md",
     "IDENTITY.md",
     "USER.md",
+    "HEARTBEAT.md",
     "AGENTS.md",
     "ENVIRONMENT.md",
 ]

--- a/squidbot/workspace/HEARTBEAT.md
+++ b/squidbot/workspace/HEARTBEAT.md
@@ -1,0 +1,13 @@
+# HEARTBEAT
+
+## Notes
+
+<!-- Keep only headings/comments to skip heartbeat checks. -->
+
+## Active
+
+<!-- Add recurring tasks as unchecked checkboxes, e.g. - [ ] Check inbox -->
+
+## Completed
+
+<!-- Move completed recurring tasks here or delete them. -->

--- a/tests/adapters/test_bootstrap_wiring.py
+++ b/tests/adapters/test_bootstrap_wiring.py
@@ -58,6 +58,7 @@ def test_bootstrap_files_onboard_excludes_bootstrap_md() -> None:
         "SOUL.md",
         "IDENTITY.md",
         "USER.md",
+        "HEARTBEAT.md",
         "AGENTS.md",
         "ENVIRONMENT.md",
     ]

--- a/tests/adapters/test_onboard.py
+++ b/tests/adapters/test_onboard.py
@@ -94,9 +94,10 @@ async def test_onboard_existing_config_kept_on_empty_input(tmp_path: Path) -> No
         return s
 
     with (
-        # api_base, api_key, model, overwrite-all=N, N×5 per-file, alias=""
+        # api_base, api_key, model, overwrite-all=N, N×6 per-file, alias=""
         patch(
-            "squidbot.cli.onboard.input", side_effect=["", "", "", "N", "N", "N", "N", "N", "N", ""]
+            "squidbot.cli.onboard.input",
+            side_effect=["", "", "", "N", "N", "N", "N", "N", "N", "N", ""],
         ),
         patch("squidbot.cli.main._load_or_init_settings", side_effect=load_with_workspace),
         patch("builtins.print"),
@@ -142,7 +143,8 @@ async def test_onboard_existing_config_overwritten_with_new_input(tmp_path: Path
                 "https://second.example.com/v1",
                 "sk-second",
                 "gpt-4o",
-                # overwrite-all=N, then N×5 per-file (one per BOOTSTRAP_FILES_MAIN)
+                # overwrite-all=N, then N×6 per-file (one per BOOTSTRAP_FILES_ONBOARD)
+                "N",
                 "N",
                 "N",
                 "N",
@@ -184,6 +186,7 @@ async def test_onboard_creates_bootstrap_files_on_fresh_workspace(tmp_path: Path
 
     for filename in BOOTSTRAP_FILES_MAIN:
         assert (workspace / filename).exists(), f"{filename} not created"
+    assert (workspace / "HEARTBEAT.md").exists()
     assert (workspace / "BOOTSTRAP.md").exists()
 
 
@@ -426,3 +429,18 @@ def test_bundled_user_template_has_preferred_language_field() -> None:
     content = user_path.read_text(encoding="utf-8")
 
     assert "- **Preferred language:**" in content
+
+
+def test_bundled_heartbeat_template_is_empty() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    heartbeat_path = repo_root / "squidbot" / "workspace" / "HEARTBEAT.md"
+
+    content = heartbeat_path.read_text(encoding="utf-8")
+
+    assert "# HEARTBEAT" in content
+    assert "## Notes" in content
+    assert "## Active" in content
+    assert "## Completed" in content
+    assert "<!-- Keep only headings/comments to skip heartbeat checks. -->" in content
+    assert "<!-- Add recurring tasks as unchecked checkboxes" in content
+    assert "\n- [ ]" not in content


### PR DESCRIPTION
## Summary
- add a bundled `HEARTBEAT.md` workspace template that is comments-only by default (no active tasks)
- include `HEARTBEAT.md` in onboarding bootstrap file creation so new workspaces get it automatically
- update onboarding/bootstrap wiring tests and heartbeat template assertions to cover the new file and expected default content

## Verification
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heartbeat template to workspace initialization for tracking recurring tasks with sections for notes, active, and completed items.

* **Tests**
  * Updated test coverage to validate heartbeat template structure and verify file creation during onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->