### PR TITLE
fix: align MEMORY.md casing and bootstrap file

### DIFF
--- a/squidbot/adapters/persistence/jsonl.py
+++ b/squidbot/adapters/persistence/jsonl.py
@@ -193,6 +193,7 @@ class JsonlMemory:
         self._base.mkdir(parents=True, exist_ok=True)
         (self._base / "workspace").mkdir(parents=True, exist_ok=True)
         (self._base / "cron").mkdir(parents=True, exist_ok=True)
+        _global_memory_file(self._base).touch(exist_ok=True)
         # In-memory cache of recent history entries.
         # Populated on first load_history call; maintained on append.
         self._history_cache: collections.deque[Message] = collections.deque()

--- a/squidbot/workspace/AGENTS.md
+++ b/squidbot/workspace/AGENTS.md
@@ -13,7 +13,7 @@ Before acting, orient yourself:
 1. Read `IDENTITY.md` — who you are
 2. Read `SOUL.md` — your values
 3. Read `USER.md` — who you're helping
-4. Check `memory.md` for relevant context
+4. Check `MEMORY.md` for relevant context
 
 ## Action Philosophy
 
@@ -29,7 +29,7 @@ Ask only before:
 
 ## Memory
 
-Your long-term memory is in `memory.md` (injected at session start).
+Your long-term memory is in `MEMORY.md` (injected at session start).
 Use `memory_write` to update it when you learn something important.
 Be selective — only record what will be useful across sessions.
 

--- a/tests/adapters/persistence/test_jsonl_global_memory.py
+++ b/tests/adapters/persistence/test_jsonl_global_memory.py
@@ -10,6 +10,11 @@ async def test_global_memory_default_empty(tmp_path):
     assert await storage.load_global_memory() == ""
 
 
+async def test_global_memory_file_created_on_init(tmp_path):
+    JsonlMemory(base_dir=tmp_path)
+    assert (tmp_path / "workspace" / "MEMORY.md").exists()
+
+
 async def test_global_memory_roundtrip(tmp_path):
     storage = JsonlMemory(base_dir=tmp_path)
     await storage.save_global_memory("User likes Python.")


### PR DESCRIPTION
## Summary
- update workspace guidance to consistently reference `MEMORY.md` (uppercase) instead of `memory.md`
- create `workspace/MEMORY.md` during `JsonlMemory` initialization so the memory file exists from first run
- add a regression test that verifies `MEMORY.md` is created on adapter init

## Verification
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured global memory file is created during initialization for improved reliability.

* **Documentation**
  * Updated memory file references in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->