### PR TITLE
fix(matrix): prevent inline math from matching $$...$$ delimiters

### DIFF
--- a/squidbot/adapters/channels/matrix_markdown.py
+++ b/squidbot/adapters/channels/matrix_markdown.py
@@ -75,7 +75,7 @@ _BLOCK_MATH_FENCE_PATTERN = (
 # form when input starts with $`.  Content must not contain backticks.
 _INLINE_MATH_PATTERN = (
     r"\$`(?P<math_text_bt>[^`]+)`\$"
-    r"|\$(?!\s)(?P<math_text>.+?)(?<!\s)\$"
+    r"|(?<!\$)\$(?![\s$])(?P<math_text>.+?)(?<![\s$])\$(?!\$)"
 )
 
 

--- a/tests/adapters/channels/test_markdown_plugins.py
+++ b/tests/adapters/channels/test_markdown_plugins.py
@@ -543,6 +543,12 @@ class TestMatrixMathPlugin:
         result = _matrix_md("Result: $ x$")
         assert "data-mx-maths" not in result
 
+    def test_inline_math_does_not_capture_double_dollar_delimiters(self) -> None:
+        """Literal $$...$$ text in a sentence is not partially parsed as inline math."""
+        result = _matrix_md("Delimiters: $$...$$")
+        assert "data-mx-maths" not in result
+        assert "$$...$$" in result
+
 
 class TestMatrixSpoilerPlugin:
     """Test Matrix-specific spoiler plugin renders ||text|| to data-mx-spoiler."""


### PR DESCRIPTION
## Summary
- Prevent `$...$` inline math parsing from matching within `$$...$$` delimiters
- Keep standard whitespace guards for inline math while excluding adjacent `$` delimiters
- Add regression test to ensure literal `$$...$$` text is not partially converted to `data-mx-maths`

## Test Plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format . --check`
- [x] `uv run mypy squidbot/`
- [x] `uv run pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced inline math detection to prevent false matches with adjacent dollar signs and reduce parsing ambiguities in edge cases.

* **Tests**
  * Added test coverage for inline math edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->