### PR TITLE
feat(core): add owner-gated slash command pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight personal AI assistant. Hexagonal architecture, multi-channel, mult
 - **Multi-model LLM pools** — named pools with ordered fallback; define providers, models, and pools independently
 - **Skills system** — on-demand skill loading, agent-created skills, hot-reload without restart
 - **Tools** — shell commands, file read/write/edit, web search, memory write, MCP servers, sub-agents (spawn)
-- **Slash commands** — cross-channel `/help` and `/new`, handled in core without an LLM roundtrip
+- **Slash commands** — cross-channel `/help`, `/new`, `/status`, and `/remember <text>`, handled in core without an LLM roundtrip (owner-only on non-CLI channels; always allowed on CLI)
 - **Heartbeat** — proactive background checks on a configurable schedule and time window
 - **Cron scheduler** — recurring tasks with cron expressions or interval syntax
 - **Long-term memory** — manual-only: global `MEMORY.md` (agent-curated, cross-channel) plus global `history.jsonl`; use `search_history` for explicit recall of older details

--- a/README.md
+++ b/README.md
@@ -295,7 +295,6 @@ Note: Slash commands are owner-only on non-CLI channels. CLI slash commands are 
 - `/help` — list available slash commands
 - `/new` — start a new logical conversation session for the current channel/session
 - `/status` — show current channel/logical session status
-- `/history` — informational guidance for explicit history recall
 - `/remember <text>` — append a memory note to global MEMORY.md
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -290,8 +290,13 @@ squidbot skills list          List all discovered skills and their availability
 
 Interactive slash commands (available across CLI, Matrix, and Email):
 
+Note: Slash commands are owner-only on non-CLI channels. CLI slash commands are always allowed.
+
 - `/help` — list available slash commands
 - `/new` — start a new logical conversation session for the current channel/session
+- `/status` — show current channel/logical session status
+- `/history` — informational guidance for explicit history recall
+- `/remember <text>` — append a memory note to global MEMORY.md
 
 ## Architecture
 

--- a/docs/plans/2026-03-03-slash-command-pack-design.md
+++ b/docs/plans/2026-03-03-slash-command-pack-design.md
@@ -1,5 +1,9 @@
 # Cross-Channel Slash Command Pack v1 - Design
 
+> Update (2026-03-04): `/history` was dropped per YAGNI. The shipped pack keeps
+> `/help`, `/new`, `/status`, and `/remember`, and `/status` now includes
+> `history_messages` count for the current logical session.
+
 ## Problem
 
 The current slash-command surface in core is intentionally minimal (`/help`, `/new`).

--- a/docs/plans/2026-03-03-slash-command-pack-design.md
+++ b/docs/plans/2026-03-03-slash-command-pack-design.md
@@ -1,201 +1,87 @@
 # Cross-Channel Slash Command Pack v1 - Design
 
-> Update (2026-03-04): `/history` was dropped per YAGNI. The shipped pack keeps
-> `/help`, `/new`, `/status`, and `/remember`, and `/status` now includes
-> `history_messages` count for the current logical session.
+## Update
+
+`/history` was removed per YAGNI. The shipped command pack includes `/help`, `/new`,
+`/status`, and `/remember <text>`.
 
 ## Problem
 
-The current slash-command surface in core is intentionally minimal (`/help`, `/new`).
-Daily operation still requires natural-language prompts for deterministic control actions
-such as checking session state, recalling older history, and writing memory notes. That
-adds avoidable LLM roundtrips and inconsistent behavior in group contexts.
+The existing slash surface is too small for deterministic session control and quick memory
+capture. Users should not need an LLM roundtrip for basic operational commands.
 
 ## Goal
 
-Add a deterministic command pack that works identically across CLI, Matrix, and Email:
+Provide deterministic slash command handling for:
 
-- `/status` - show current session context state.
-- `/history` - show how to recall history (informational command only).
-- `/remember <text>` - persist a memory note through existing memory workflow.
+- `/help`
+- `/new`
+- `/status`
+- `/remember <text>`
 
-All command handling must bypass LLM inference and return immediate responses.
+All slash commands must execute without calling the LLM.
 
-## Scope
+## Authorization Policy
 
-### In scope
+- CLI: slash commands are always allowed (physical host access implies owner control).
+- Non-CLI channels: slash commands are owner-only.
+- Matrix owner resolution uses `matrix_sender_id` from metadata.
+- Missing/invalid attribution on non-CLI channels returns:
+  `Access denied: slash commands are only available to the owner.`
 
-- Extend core slash-command parsing to support arguments and action metadata.
-- Add deterministic handlers for `/status`, `/history`, `/remember`.
-- Enforce owner-only authorization policy for all slash commands.
-- Keep channel behavior uniform by handling commands only in `AgentLoop`.
-- Reuse existing memory-write pathway for `/remember`.
-- Add serialization semantics for `/remember` read-modify-write path.
-- Add tests for happy paths, validation errors, authorization, and runtime failures.
+## Command Contracts
 
-### Out of scope
+### `/status`
 
-- Command flags/options (`--limit`, `--json`, etc.).
-- Command aliases (`/mem`, `/find`, etc.).
-- Channel-specific parser differences.
-- Generalized role/permissions framework beyond this command pack.
+Returns deterministic session diagnostics:
 
-## Command Authorization
+- `channel`
+- `physical_session`
+- `logical_session`
+- `next_turn_history_backfill`
+- `history_messages` (count of persisted messages in current logical session)
 
-All slash commands are restricted to the owner:
+If status construction fails, return deterministic text:
+`Error: unable to build session status right now.`
 
-- Owner-only: `/help`, `/new`, `/status`, `/history`, `/remember`
+### `/remember <text>`
 
-Owner detection reuses existing owner alias matching already used in memory attribution.
-CLI channel is always authorized for slash commands (physical host access implies owner).
-
-If sender attribution is missing or does not match owner policy, slash execution is denied
-with deterministic response:
-
-- `Access denied: slash commands are only available to the owner.`
-
-This is command-scoped policy, not a new global permissions subsystem.
-
-## Authoritative Sender Identity
-
-Slash authorization uses a channel-aware actor identity source:
-
-- Non-Matrix channels: `user_sender_id` when provided, otherwise `session.sender_id`.
-- Matrix: `outbound_metadata["matrix_sender_id"]` only.
-
-Matrix `session.sender_id` is room-scoped and is not used for owner authorization.
-If `matrix_sender_id` is missing/empty, slash commands are denied deterministically.
-
-Auth input precedence is therefore:
-
-1. Matrix channel: metadata sender only.
-2. Other channels: explicit `user_sender_id`.
-3. Other channels fallback: `session.sender_id`.
+- Requires non-empty `<text>`.
+- Merges note as a markdown bullet into global memory via `memory_write`.
+- Uses an async lock for slash-path serialization.
+- If `memory_write` is unavailable, return deterministic error.
+- If tool raises, returns error text.
+- If tool returns an invalid shape, return deterministic error:
+  `Error: memory_write returned an invalid result.`
 
 ## Architecture
 
-### 1) Core command router enhancement
-
-Extend `squidbot/core/slash_commands.py` from command-only parsing to command-plus-args
-parsing. The router returns a structured result object including optional action and
-argument fields for runtime dispatch.
-
-### 2) AgentLoop fast-path dispatch
-
-`AgentLoop.run()` keeps slash handling before typing indicators and before any LLM call.
-
-- Slash input first runs authorization checks.
-- Authorized static commands (`/help`, `/new`, `/status`) are resolved directly.
-- Authorized tool-backed commands (`/history`, `/remember`) dispatch via helpers.
-
-This preserves deterministic behavior and avoids adapter-level command parsing.
-
-### 3) `/history` informational contract
-
-`/history` is intentionally informational (YAGNI) and does not read history directly.
-It returns deterministic guidance text that points the owner to explicit history recall
-via normal assistant interaction and existing history tooling.
-
-### 4) `/remember` concurrency semantics
-
-`/remember` uses read-modify-write over global `MEMORY.md`, which is race-prone under
-concurrent channel loops. To prevent silent lost updates, slash `/remember` writes are
-serialized in-process with a shared async lock around:
-
-1. load current memory text,
-2. merge appended bullet line,
-3. write via `memory_write`.
-
-Guarantee: no lost updates for concurrent slash `/remember` commands in one process.
-Non-slash `memory_write` calls (LLM/tooling/cron/heartbeat) keep existing behavior and
-are out of scope for this command-pack guarantee.
-
-## Rollout Preconditions
-
-- CLI channel is always authorized for slash commands.
-- Matrix and Email slash use require configured owner aliases for those channels.
-- Without matching owner alias attribution, slash commands are denied by policy.
-
-## `/status` Response Contract
-
-`/status` returns a fixed, testable text schema:
-
-- `Current session status:`
-- `- channel: <channel>`
-- `- physical_session: <session-id>`
-- `- logical_session: <session-id or session-id#gN>`
-- `- next_turn_history_backfill: <true|false>`
-
-Field names are stable and must not vary across channels.
-
-## Components
-
 - `squidbot/core/slash_commands.py`
-  - Parse `/command args` safely.
-  - Normalize command names (`lower()`).
-  - Return structured action requests for runtime execution.
+  - Parse command + argument.
+  - Emit action metadata for `status` and `remember`.
 - `squidbot/core/agent.py`
-  - Add command dispatch helpers (`_handle_status_command`,
-    `_handle_history_command`, `_handle_remember_command`).
-  - Enforce owner-only access for all slash commands.
-  - Serialize `/remember` writes with shared lock.
-  - Execute command actions before typing/LLM flow.
-- `tests/core/test_agent.py`
-  - Add coverage for bypass, authorization, and error paths.
-- `tests/core/test_slash_commands.py`
-  - Validate parser behavior for args, empty args, and unknown commands.
-- `tests/adapters/test_channel_loops.py`
-  - Add parity test showing slash behavior is channel-agnostic through gateway loops.
+  - Authorize slash calls.
+  - Dispatch command actions before typing/LLM path.
+  - Build status payload and memory-write flow.
+- `squidbot/core/memory.py`
+  - Owner-check helper.
+  - Global memory load helper.
+  - Session history count helper for status.
 
-## Data Flow
+## Testing Strategy
 
-1. User sends message in any channel.
-2. `AgentLoop` detects string input and calls slash router.
-3. If router returns `handled=True`:
-   - Resolve authoritative actor sender from channel-specific sources.
-   - Run owner check and deny if unauthorized.
-   - `/status`: build fixed-schema response from in-memory session state and send.
-   - `/history`: send informational history guidance text.
-   - `/remember <text>`: validate text, run serialized memory-write workflow, send.
-   - Return immediately.
-4. If not handled, continue normal typing -> LLM -> tools pipeline.
-
-## Error Handling
-
-- Unknown command: deterministic error with `/help` hint.
-- Missing argument for `/remember`: usage guidance.
-- Unauthorized sender on non-CLI slash commands: deterministic access-denied response.
-- Matrix slash request without `matrix_sender_id`: deterministic access-denied response.
-- Missing required tool registration: deterministic unavailable response.
-- Tool runtime exception or `ToolResult(is_error=True)`: concise user-visible error text,
-  no fallback LLM interpretation.
-
-## Testing Approach
-
-- Parser tests:
-  - `/status`, `/history foo`, `/remember bar` parse correctly.
-  - `/history` and `/remember` without args return validation errors.
-  - Unknown command behavior remains unchanged.
-- Core agent tests:
-  - `/status`, `/history`, `/remember` bypass LLM calls.
-  - Owner-only policy enforced for `/help`, `/new`, `/status`, `/history`, and `/remember`.
-  - Matrix owner auth uses `matrix_sender_id` provenance only.
-  - Missing Matrix sender attribution is denied deterministically.
-  - `/status` exact field contract is asserted.
-  - Failure paths cover missing tool, tool exception, and `ToolResult(is_error=True)`.
-  - Concurrency test verifies no lost notes for concurrent slash `/remember` commands.
-- Gateway/channel parity:
-  - At least one channel-loop level test proves slash behavior remains identical across
-    channel adapters because command handling stays in `AgentLoop`.
+- Parser tests for `/status`, `/remember`, unknown commands.
+- Agent tests for:
+  - no-LLM slash execution,
+  - CLI allow / non-CLI deny,
+  - Matrix metadata sender auth,
+  - `/status` contract and failure fallback,
+  - `/remember` success + failure paths (missing tool, exception, error result,
+    invalid result shape).
 
 ## Success Criteria
 
-- Three new commands work consistently across CLI, Matrix, and Email.
-- No LLM request occurs for slash command execution.
-- Owner-only guard is enforced for all slash commands.
-- `/history` slash response stays informational-only (no direct history retrieval).
-- Matrix slash authorization is based on `matrix_sender_id` provenance.
-- Missing Matrix sender attribution denies slash deterministically.
-- `/remember` avoids lost updates for concurrent slash `/remember` calls.
-- Existing `/help` and `/new` behavior remains stable.
-- Full test suite passes with strict lint/type gates.
+- Slash behavior is deterministic and channel-consistent.
+- `/status` includes `history_messages`.
+- `/remember` is robust against expected tool failure modes.
+- `/history` is not part of shipped slash surface.

--- a/docs/plans/2026-03-03-slash-command-pack-design.md
+++ b/docs/plans/2026-03-03-slash-command-pack-design.md
@@ -1,0 +1,197 @@
+# Cross-Channel Slash Command Pack v1 - Design
+
+## Problem
+
+The current slash-command surface in core is intentionally minimal (`/help`, `/new`).
+Daily operation still requires natural-language prompts for deterministic control actions
+such as checking session state, recalling older history, and writing memory notes. That
+adds avoidable LLM roundtrips and inconsistent behavior in group contexts.
+
+## Goal
+
+Add a deterministic command pack that works identically across CLI, Matrix, and Email:
+
+- `/status` - show current session context state.
+- `/history` - show how to recall history (informational command only).
+- `/remember <text>` - persist a memory note through existing memory workflow.
+
+All command handling must bypass LLM inference and return immediate responses.
+
+## Scope
+
+### In scope
+
+- Extend core slash-command parsing to support arguments and action metadata.
+- Add deterministic handlers for `/status`, `/history`, `/remember`.
+- Enforce owner-only authorization policy for all slash commands.
+- Keep channel behavior uniform by handling commands only in `AgentLoop`.
+- Reuse existing memory-write pathway for `/remember`.
+- Add serialization semantics for `/remember` read-modify-write path.
+- Add tests for happy paths, validation errors, authorization, and runtime failures.
+
+### Out of scope
+
+- Command flags/options (`--limit`, `--json`, etc.).
+- Command aliases (`/mem`, `/find`, etc.).
+- Channel-specific parser differences.
+- Generalized role/permissions framework beyond this command pack.
+
+## Command Authorization
+
+All slash commands are restricted to the owner:
+
+- Owner-only: `/help`, `/new`, `/status`, `/history`, `/remember`
+
+Owner detection reuses existing owner alias matching already used in memory attribution.
+CLI channel is always authorized for slash commands (physical host access implies owner).
+
+If sender attribution is missing or does not match owner policy, slash execution is denied
+with deterministic response:
+
+- `Access denied: slash commands are only available to the owner.`
+
+This is command-scoped policy, not a new global permissions subsystem.
+
+## Authoritative Sender Identity
+
+Slash authorization uses a channel-aware actor identity source:
+
+- Non-Matrix channels: `user_sender_id` when provided, otherwise `session.sender_id`.
+- Matrix: `outbound_metadata["matrix_sender_id"]` only.
+
+Matrix `session.sender_id` is room-scoped and is not used for owner authorization.
+If `matrix_sender_id` is missing/empty, slash commands are denied deterministically.
+
+Auth input precedence is therefore:
+
+1. Matrix channel: metadata sender only.
+2. Other channels: explicit `user_sender_id`.
+3. Other channels fallback: `session.sender_id`.
+
+## Architecture
+
+### 1) Core command router enhancement
+
+Extend `squidbot/core/slash_commands.py` from command-only parsing to command-plus-args
+parsing. The router returns a structured result object including optional action and
+argument fields for runtime dispatch.
+
+### 2) AgentLoop fast-path dispatch
+
+`AgentLoop.run()` keeps slash handling before typing indicators and before any LLM call.
+
+- Slash input first runs authorization checks.
+- Authorized static commands (`/help`, `/new`, `/status`) are resolved directly.
+- Authorized tool-backed commands (`/history`, `/remember`) dispatch via helpers.
+
+This preserves deterministic behavior and avoids adapter-level command parsing.
+
+### 3) `/history` informational contract
+
+`/history` is intentionally informational (YAGNI) and does not read history directly.
+It returns deterministic guidance text that points the owner to explicit history recall
+via normal assistant interaction and existing history tooling.
+
+### 4) `/remember` concurrency semantics
+
+`/remember` uses read-modify-write over global `MEMORY.md`, which is race-prone under
+concurrent channel loops. To prevent silent lost updates, slash `/remember` writes are
+serialized in-process with a shared async lock around:
+
+1. load current memory text,
+2. merge appended bullet line,
+3. write via `memory_write`.
+
+Guarantee: no lost updates for concurrent slash `/remember` commands in one process.
+Non-slash `memory_write` calls (LLM/tooling/cron/heartbeat) keep existing behavior and
+are out of scope for this command-pack guarantee.
+
+## Rollout Preconditions
+
+- CLI channel is always authorized for slash commands.
+- Matrix and Email slash use require configured owner aliases for those channels.
+- Without matching owner alias attribution, slash commands are denied by policy.
+
+## `/status` Response Contract
+
+`/status` returns a fixed, testable text schema:
+
+- `Current session status:`
+- `- channel: <channel>`
+- `- physical_session: <session-id>`
+- `- logical_session: <session-id or session-id#gN>`
+- `- next_turn_history_backfill: <true|false>`
+
+Field names are stable and must not vary across channels.
+
+## Components
+
+- `squidbot/core/slash_commands.py`
+  - Parse `/command args` safely.
+  - Normalize command names (`lower()`).
+  - Return structured action requests for runtime execution.
+- `squidbot/core/agent.py`
+  - Add command dispatch helpers (`_handle_status_command`,
+    `_handle_history_command`, `_handle_remember_command`).
+  - Enforce owner-only access for all slash commands.
+  - Serialize `/remember` writes with shared lock.
+  - Execute command actions before typing/LLM flow.
+- `tests/core/test_agent.py`
+  - Add coverage for bypass, authorization, and error paths.
+- `tests/core/test_slash_commands.py`
+  - Validate parser behavior for args, empty args, and unknown commands.
+- `tests/adapters/test_channel_loops.py`
+  - Add parity test showing slash behavior is channel-agnostic through gateway loops.
+
+## Data Flow
+
+1. User sends message in any channel.
+2. `AgentLoop` detects string input and calls slash router.
+3. If router returns `handled=True`:
+   - Resolve authoritative actor sender from channel-specific sources.
+   - Run owner check and deny if unauthorized.
+   - `/status`: build fixed-schema response from in-memory session state and send.
+   - `/history`: send informational history guidance text.
+   - `/remember <text>`: validate text, run serialized memory-write workflow, send.
+   - Return immediately.
+4. If not handled, continue normal typing -> LLM -> tools pipeline.
+
+## Error Handling
+
+- Unknown command: deterministic error with `/help` hint.
+- Missing argument for `/remember`: usage guidance.
+- Unauthorized sender on non-CLI slash commands: deterministic access-denied response.
+- Matrix slash request without `matrix_sender_id`: deterministic access-denied response.
+- Missing required tool registration: deterministic unavailable response.
+- Tool runtime exception or `ToolResult(is_error=True)`: concise user-visible error text,
+  no fallback LLM interpretation.
+
+## Testing Approach
+
+- Parser tests:
+  - `/status`, `/history foo`, `/remember bar` parse correctly.
+  - `/history` and `/remember` without args return validation errors.
+  - Unknown command behavior remains unchanged.
+- Core agent tests:
+  - `/status`, `/history`, `/remember` bypass LLM calls.
+  - Owner-only policy enforced for `/help`, `/new`, `/status`, `/history`, and `/remember`.
+  - Matrix owner auth uses `matrix_sender_id` provenance only.
+  - Missing Matrix sender attribution is denied deterministically.
+  - `/status` exact field contract is asserted.
+  - Failure paths cover missing tool, tool exception, and `ToolResult(is_error=True)`.
+  - Concurrency test verifies no lost notes for concurrent slash `/remember` commands.
+- Gateway/channel parity:
+  - At least one channel-loop level test proves slash behavior remains identical across
+    channel adapters because command handling stays in `AgentLoop`.
+
+## Success Criteria
+
+- Three new commands work consistently across CLI, Matrix, and Email.
+- No LLM request occurs for slash command execution.
+- Owner-only guard is enforced for all slash commands.
+- `/history` slash response stays informational-only (no direct history retrieval).
+- Matrix slash authorization is based on `matrix_sender_id` provenance.
+- Missing Matrix sender attribution denies slash deterministically.
+- `/remember` avoids lost updates for concurrent slash `/remember` calls.
+- Existing `/help` and `/new` behavior remains stable.
+- Full test suite passes with strict lint/type gates.

--- a/docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
+++ b/docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
@@ -1,5 +1,8 @@
 # Slash Command Pack v1 Implementation Plan
 
+> Update (2026-03-04): `/history` was removed (YAGNI). Status now reports
+> logical-session history size via `history_messages`.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add deterministic cross-channel `/status`, `/history`, and `/remember <text>` slash commands that bypass LLM roundtrips while enforcing owner-only access for all slash commands.

--- a/docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
+++ b/docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
@@ -1,469 +1,67 @@
 # Slash Command Pack v1 Implementation Plan
 
-> Update (2026-03-04): `/history` was removed (YAGNI). Status now reports
-> logical-session history size via `history_messages`.
-
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Add deterministic cross-channel `/status`, `/history`, and `/remember <text>` slash commands that bypass LLM roundtrips while enforcing owner-only access for all slash commands.
+**Goal:** Ship deterministic owner-gated slash commands (`/help`, `/new`, `/status`, `/remember <text>`) with `/status` history count and robust `/remember` error handling.
 
-**Architecture:** Extend core slash parsing with action+argument metadata, then dispatch actions in `AgentLoop` before typing/LLM flow. Introduce a channel-aware sender resolver for auth (`matrix_sender_id` provenance on Matrix; sender/session fallback elsewhere), keep behavior channel-agnostic by centralizing handling in core, keep `/history` informational-only (no direct history retrieval), and serialize slash `/remember` read-modify-write with an async lock.
+**Architecture:** Keep parsing in `slash_commands.py`, execution/authorization in `AgentLoop`, and owner/history helpers in `MemoryManager`. Do not ship `/history` as a slash command.
 
-**Tech Stack:** Python 3.14, pytest, ruff, mypy --strict, existing `ToolRegistry`, `MemoryManager`, and tool adapters.
+**Tech Stack:** Python 3.14, pytest, ruff, mypy --strict.
 
 ---
 
-## Requirement-to-Test Traceability Matrix
+## Requirement-to-Test Matrix
 
-| Requirement | Planned tests |
+| Requirement | Tests |
 |---|---|
-| Slash commands bypass LLM | existing owner-path tests for `/help` + `/new` in `tests/core/test_agent.py`, plus `tests/core/test_agent.py::test_slash_status_returns_without_llm_call`, `tests/core/test_agent.py::test_slash_history_returns_without_llm_call`, `tests/core/test_agent.py::test_slash_remember_returns_without_llm_call` |
-| Owner-only all slash commands | `tests/core/test_agent.py::test_slash_help_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_new_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_status_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_history_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_remember_denied_for_non_owner` |
-| `/status` stable response schema | `tests/core/test_agent.py::test_slash_status_response_contract` |
-| `/history` informational-only behavior | `tests/core/test_agent.py::test_slash_history_returns_informational_guidance_without_llm_call` |
-| Matrix sender provenance for slash auth | `tests/core/test_agent.py::test_slash_matrix_owner_allowed_via_metadata_sender`, `tests/core/test_agent.py::test_slash_matrix_non_owner_denied_via_metadata_sender` |
-| Missing attribution => deterministic deny | `tests/core/test_agent.py::test_slash_matrix_missing_sender_metadata_denied` |
-| `/remember` no lost updates for concurrent slash calls | `tests/core/test_agent.py::test_slash_remember_concurrent_calls_preserve_both_notes` |
-| Cross-channel parity of slash behavior | `tests/adapters/test_channel_loops.py::test_channel_loop_forwards_slash_messages_channel_agnostic` |
-| Existing `/help` + `/new` behavior for owner unchanged | existing slash tests in `tests/core/test_agent.py` with owner sender + parser regression tests |
+| Slash commands bypass LLM | existing `/help` + `/new` tests plus slash status/remember tests in `tests/core/test_agent.py` |
+| CLI slash always allowed | `test_slash_commands_always_allowed_on_cli` |
+| Non-CLI slash owner-only | `test_slash_commands_denied_for_non_cli_non_owner` |
+| Matrix auth uses metadata sender | `test_slash_matrix_auth_uses_metadata_sender`, `test_slash_matrix_missing_metadata_sender_is_denied` |
+| `/status` includes `history_messages` | `test_slash_status_returns_contract_without_llm_call`, `test_slash_status_includes_current_logical_history_size` |
+| `/status` deterministic error fallback | `test_slash_status_returns_deterministic_error_when_history_count_fails` |
+| `/remember` failure-path resilience | remember failure tests in `tests/core/test_agent.py` |
+| `/history` not shipped | parser + agent unknown-command tests |
 
-### Task 1: Add failing parser tests (including validation and command metadata)
+## Tasks
 
-**Files:**
-- Create: `tests/core/test_slash_commands.py`
-- Modify: `squidbot/core/slash_commands.py` (later task)
-
-**Step 1: Write RED tests for parser behavior**
-
-```python
-from squidbot.core.slash_commands import handle_slash_command
-
-
-def test_slash_status_sets_action() -> None:
-    result = handle_slash_command("/status")
-    assert result.handled is True
-    assert result.action == "status"
-
-
-def test_slash_history_is_informational() -> None:
-    result = handle_slash_command("/history")
-    assert result.handled is True
-    assert result.action == "history"
-    assert result.is_error is False
-
-
-def test_slash_remember_requires_argument() -> None:
-    result = handle_slash_command("/remember   ")
-    assert result.handled is True
-    assert result.is_error is True
-    assert result.response_text == "Usage: /remember <text>"
-```
-
-**Step 2: Run RED tests**
-
-Run: `uv run pytest tests/core/test_slash_commands.py -v`
-Expected: FAIL because metadata fields and command branches do not exist yet.
-
-**Step 3: Commit RED tests**
-
-```bash
-git add tests/core/test_slash_commands.py
-git commit -m "test(core): add slash parser red tests for command pack"
-```
-
-### Task 2: Implement slash parser extensions and help text updates
+### Task 1: Parser Contract
 
 **Files:**
 - Modify: `squidbot/core/slash_commands.py`
 - Test: `tests/core/test_slash_commands.py`
 
-**Step 1: Extend `SlashCommandResult` contract**
-
-```python
-@dataclass(frozen=True)
-class SlashCommandResult:
-    handled: bool
-    response_text: str = ""
-    reset_requested: bool = False
-    action: str | None = None
-    argument: str | None = None
-    is_error: bool = False
-```
-
-**Step 2: Parse command + argument and add branches**
-
-```python
-cmd, arg = _split_slash_input(stripped)
-
-if cmd == "/status":
-    return SlashCommandResult(handled=True, action="status")
-if cmd == "/history":
-    return SlashCommandResult(handled=True, action="history")
-if cmd == "/remember":
-    if not arg:
-        return SlashCommandResult(handled=True, is_error=True, response_text="Usage: /remember <text>")
-    return SlashCommandResult(handled=True, action="remember", argument=arg)
-```
-
-**Step 3: Update `HELP_TEXT` with all commands**
-
-**Step 4: Run parser tests to GREEN**
-
-Run: `uv run pytest tests/core/test_slash_commands.py -v`
-Expected: PASS.
-
-**Step 5: Commit parser changes**
-
-```bash
-git add squidbot/core/slash_commands.py tests/core/test_slash_commands.py
-git commit -m "feat(core): extend slash parser with command metadata"
-```
-
-### Task 3: Add failing core tests for authorization and `/status` contract
-
-**Files:**
-- Modify: `tests/core/test_agent.py`
-- Modify: `squidbot/core/memory.py` (later task)
-- Modify: `squidbot/core/agent.py` (later task)
-
-**Step 1: Write RED tests for owner-only behavior**
-
-```python
-async def test_slash_history_denied_for_non_owner(storage):
-    memory = MemoryManager(storage=storage, owner_aliases=[OwnerAliasEntry(address="owner", channel="cli")])
-    session = Session(channel="cli", sender_id="guest")
-    ...
-    await loop.run(session, "/history token", channel)
-    assert channel.sent[0].text == "Access denied: slash commands are only available to the owner."
-```
-
-```python
-async def test_slash_help_denied_for_non_owner(storage): ...
-async def test_slash_new_denied_for_non_owner(storage): ...
-async def test_slash_status_denied_for_non_owner(storage): ...
-async def test_slash_remember_denied_for_non_owner(storage): ...
-```
-
-**Step 2: Write RED Matrix sender-provenance tests**
-
-```python
-async def test_slash_matrix_owner_allowed_via_metadata_sender(storage):
-    # session.sender_id is room-like, owner identity comes from metadata sender
-    session = Session(channel="matrix", sender_id="!room:example.org")
-    metadata = {"matrix_sender_id": "@owner:example.org"}
-    ...
-
-
-async def test_slash_matrix_non_owner_denied_via_metadata_sender(storage): ...
-
-
-async def test_slash_matrix_missing_sender_metadata_denied(storage): ...
-```
-
-**Step 3: Write RED test for exact `/status` schema**
-
-```python
-async def test_slash_status_response_contract(storage, memory):
-    await loop.run(SESSION, "/status", channel)
-    assert channel.sent[0].text.splitlines() == [
-        "Current session status:",
-        f"- channel: {SESSION.channel}",
-        f"- physical_session: {SESSION.id}",
-        f"- logical_session: {SESSION.id}",
-        "- next_turn_history_backfill: true",
-    ]
-```
-
-**Step 4: Add RED test for CLI always-allowed policy**
-
-```python
-async def test_slash_cli_always_allowed(storage):
-    memory = MemoryManager(storage=storage, owner_aliases=[OwnerAliasEntry(address="someone", channel="email")])
-    session = Session(channel="cli", sender_id="random-cli-user")
-    ...
-    await loop.run(session, "/help", channel)
-    assert "Available commands" in channel.sent[0].text
-```
-
-**Step 5: Run RED tests**
-
-Run: `uv run pytest tests/core/test_agent.py -v`
-Expected: FAIL on missing authorization and exact status formatting.
-
-**Step 6: Commit RED tests**
-
-```bash
-git add tests/core/test_agent.py
-git commit -m "test(core): add slash auth and status contract red tests"
-```
-
-### Task 4: Implement owner authorization and `/status` contract
-
-**Files:**
-- Modify: `squidbot/core/memory.py`
-- Modify: `squidbot/core/agent.py`
-- Test: `tests/core/test_agent.py`
-
-**Step 1: Add public owner-check method on `MemoryManager` with CLI allow policy**
-
-```python
-def is_owner_sender(self, sender_id: str | None, channel: str) -> bool:
-    if channel == "cli":
-        return True
-    if sender_id is None:
-        return False
-    return self._is_owner(sender_id, channel)
-```
-
-**Step 2: Add channel-aware sender resolver helper in `AgentLoop`**
-
-```python
-def _resolve_slash_actor_sender(
-    self,
-    session: Session,
-    user_sender_id: str | None,
-    outbound_metadata: dict[str, Any] | None,
-) -> str | None:
-    if session.channel == "matrix":
-        sender = (outbound_metadata or {}).get("matrix_sender_id")
-        return sender if isinstance(sender, str) and sender else None
-    if user_sender_id:
-        return user_sender_id
-    return session.sender_id
-```
-
-**Step 3: Add slash authorization guard in `AgentLoop` for all slash commands**
-
-```python
-actor_sender = self._resolve_slash_actor_sender(session, user_sender_id, outbound_metadata)
-if slash_result.handled and not self._memory.is_owner_sender(actor_sender, session.channel):
-    await channel.send(
-        OutboundMessage(..., text="Access denied: slash commands are only available to the owner.")
-    )
-    return
-```
-
-**Step 4: Implement fixed `/status` formatter**
-
-```python
-def _build_status_text(self, session: Session) -> str:
-    ...
-```
-
-**Step 5: Run focused tests to GREEN**
-
-Run: `uv run pytest tests/core/test_agent.py -k "slash and (status or denied or cli_always or matrix)" -v`
-Expected: PASS.
-
-**Step 6: Commit implementation**
-
-```bash
-git add squidbot/core/memory.py squidbot/core/agent.py tests/core/test_agent.py
-git commit -m "feat(core): enforce slash auth and status response contract"
-```
-
-### Task 5: Add failing tests for `/history` informational behavior
-
-**Files:**
-- Modify: `tests/core/test_agent.py`
-- Modify: `squidbot/core/agent.py` (later task)
-
-**Step 1: Add RED tests for informational `/history`**
-
-```python
-async def test_slash_history_returns_informational_guidance_without_llm_call(storage, memory):
-    ...
-    await loop.run(SESSION, "/history", channel)
-    assert "informational" in channel.sent[0].text.lower()
-    assert "search_history" in channel.sent[0].text
-
-
-async def test_slash_history_ignores_extra_arguments(storage, memory):
-    ...
-    await loop.run(SESSION, "/history project x", channel)
-    assert "search_history" in channel.sent[0].text
-```
-
-**Step 2: Run RED tests**
-
-Run: `uv run pytest tests/core/test_agent.py -k "slash and history" -v`
-Expected: FAIL because `/history` action is not implemented yet.
-
-**Step 3: Commit RED tests**
-
-```bash
-git add tests/core/test_agent.py
-git commit -m "test(core): add informational slash history red tests"
-```
-
-### Task 6: Implement informational slash `/history` dispatch
-
-**Files:**
-- Modify: `squidbot/core/agent.py`
-- Modify: `tests/core/test_agent.py`
-
-**Step 1: Add deterministic informational text for `/history` in `AgentLoop`**
-
-```python
-def _build_history_info_text(self) -> str:
-    return (
-        "History command is informational only. "
-        "To recall past details, ask me to run search_history with your query."
-    )
-```
-
-**Step 2: Dispatch `/history` action without tool calls**
-
-```python
-if slash_result.action == "history":
-    await channel.send(OutboundMessage(session=session, text=self._build_history_info_text(), ...))
-    return
-```
-
-**Step 3: Add assertion that `/history` does not require `search_history` tool registration**
-
-**Step 4: Run focused tests to GREEN**
-
-Run:
-- `uv run pytest tests/core/test_agent.py -k "slash and history" -v`
-
-Expected: PASS.
-
-**Step 5: Commit implementation**
-
-```bash
-git add squidbot/core/agent.py tests/core/test_agent.py
-git commit -m "feat(core): add informational slash history command"
-```
-
-### Task 7: Add failing `/remember` concurrency and error-path tests
-
-**Files:**
-- Modify: `tests/core/test_agent.py`
-- Modify: `squidbot/core/agent.py` (later task)
-
-**Step 1: Add RED concurrency test**
-
-```python
-async def test_slash_remember_concurrent_calls_preserve_both_notes(storage, memory):
-    await asyncio.gather(
-        loop.run(owner_session, "/remember note-one", channel),
-        loop.run(owner_session, "/remember note-two", channel),
-    )
-    saved = await storage.load_global_memory()
-    assert "note-one" in saved
-    assert "note-two" in saved
-```
-
-**Step 2: Add RED failure-path tests for `/remember`**
-
-- missing `memory_write` tool
-- tool raises exception
-- tool returns `ToolResult(is_error=True)`
-
-**Step 3: Run RED tests**
-
-Run: `uv run pytest tests/core/test_agent.py -k "slash and remember" -v`
-Expected: FAIL due to no lock and incomplete error handling.
-
-**Step 4: Commit RED tests**
-
-```bash
-git add tests/core/test_agent.py
-git commit -m "test(core): add slash remember concurrency red tests"
-```
-
-### Task 8: Implement serialized `/remember` workflow
+1. Keep `/status` and `/remember` parser actions.
+2. Keep `/history` as unknown command.
+3. Keep `/remember` usage validation.
+4. Run: `uv run pytest tests/core/test_slash_commands.py -v`
+
+### Task 2: Agent Slash Dispatch
 
 **Files:**
 - Modify: `squidbot/core/agent.py`
 - Modify: `squidbot/core/memory.py`
 - Test: `tests/core/test_agent.py`
 
-**Step 1: Add shared async lock in `AgentLoop`**
+1. Keep owner authorization policy (CLI allow, non-CLI owner-only).
+2. Keep `/status` payload with `history_messages`.
+3. Add `/status` local exception containment with deterministic error text.
+4. Harden `/remember` invalid tool result handling.
+5. Run: `uv run pytest tests/core/test_agent.py -k "slash" -v`
 
-```python
-self._remember_lock = asyncio.Lock()
-```
-
-**Step 2: Add helper to read global memory text through `MemoryManager`**
-
-```python
-async def load_global_memory_text(self) -> str:
-    return await self._storage.load_global_memory()
-```
-
-**Step 3: Serialize `/remember` read-modify-write**
-
-```python
-async with self._remember_lock:
-    existing = await self._memory.load_global_memory_text()
-    merged = _append_memory_note(existing, note)
-    result = await memory_tool.execute(content=merged)
-```
-
-**Step 4: Narrow and enforce guarantee scope explicitly**
-
-- Guarantee applies to concurrent slash `/remember` calls only.
-- Non-slash `memory_write` write ordering remains existing behavior.
-- Ensure docs and test names reflect slash-scoped concurrency guarantee.
-
-**Step 5: Normalize slash error handling for exceptions and error results**
-
-**Step 6: Run focused tests to GREEN**
-
-Run: `uv run pytest tests/core/test_agent.py -k "slash and remember" -v`
-Expected: PASS.
-
-**Step 7: Commit implementation**
-
-```bash
-git add squidbot/core/agent.py squidbot/core/memory.py tests/core/test_agent.py
-git commit -m "fix(core): serialize slash remember writes to avoid races"
-```
-
-### Task 9: Add channel-loop parity test for slash forwarding
+### Task 3: Test Coverage and Docs
 
 **Files:**
-- Modify: `tests/adapters/test_channel_loops.py`
-
-**Step 1: Add parity-focused test**
-
-```python
-async def test_channel_loop_forwards_slash_messages_channel_agnostic():
-    # run _channel_loop twice with different channel/session labels (matrix/email)
-    # assert loop.run receives slash text unchanged in both cases
-```
-
-**Step 2: Run targeted parity tests**
-
-Run: `uv run pytest tests/adapters/test_channel_loops.py -v`
-Expected: PASS.
-
-**Step 3: Commit parity test**
-
-```bash
-git add tests/adapters/test_channel_loops.py
-git commit -m "test(adapters): verify slash forwarding parity across channel loops"
-```
-
-### Task 10: Update docs and run full verification gates
-
-**Files:**
+- Modify: `tests/core/test_agent.py`
+- Modify: `tests/core/test_slash_commands.py`
 - Modify: `README.md`
-- Verify: `docs/plans/2026-03-03-slash-command-pack-design.md`
-- Verify: `docs/plans/2026-03-03-slash-command-pack-implementation-plan.md`
 
-**Step 1: Update README slash command list and owner-only notes**
+1. Add `/remember` failure-path tests (missing tool, exception, error result, invalid result shape).
+2. Keep parser and status tests aligned with current command set.
+3. Keep both README command lists synchronized.
+4. Run: `uv run pytest tests/core/test_agent.py tests/core/test_slash_commands.py -v`
 
-```markdown
-- Slash commands are owner-only (`/help`, `/new`, `/status`, `/history`, `/remember`)
-- `/status` — show current logical session status
-- `/history` — informational guidance for explicit history recall
-- `/remember <text>` — append memory note
-```
-
-**Step 2: Run full quality gates**
+### Task 4: Full Verification
 
 Run:
 - `uv run ruff check .`
@@ -471,15 +69,4 @@ Run:
 - `uv run mypy squidbot/`
 - `uv run pytest`
 
-Additional verification:
-- confirm non-slash Matrix mention/allowlist behavior remains unchanged by slash auth layer
-  (`uv run pytest tests/adapters/channels/test_matrix.py -k "mention or allowlist" -v`)
-
-Expected: all PASS.
-
-**Step 3: Final docs commit**
-
-```bash
-git add README.md docs/plans/2026-03-03-slash-command-pack-design.md docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
-git commit -m "docs: harden slash command pack plan with auth and race controls"
-```
+All commands must pass before final commit/push.

--- a/docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
+++ b/docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
@@ -1,0 +1,482 @@
+# Slash Command Pack v1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add deterministic cross-channel `/status`, `/history`, and `/remember <text>` slash commands that bypass LLM roundtrips while enforcing owner-only access for all slash commands.
+
+**Architecture:** Extend core slash parsing with action+argument metadata, then dispatch actions in `AgentLoop` before typing/LLM flow. Introduce a channel-aware sender resolver for auth (`matrix_sender_id` provenance on Matrix; sender/session fallback elsewhere), keep behavior channel-agnostic by centralizing handling in core, keep `/history` informational-only (no direct history retrieval), and serialize slash `/remember` read-modify-write with an async lock.
+
+**Tech Stack:** Python 3.14, pytest, ruff, mypy --strict, existing `ToolRegistry`, `MemoryManager`, and tool adapters.
+
+---
+
+## Requirement-to-Test Traceability Matrix
+
+| Requirement | Planned tests |
+|---|---|
+| Slash commands bypass LLM | existing owner-path tests for `/help` + `/new` in `tests/core/test_agent.py`, plus `tests/core/test_agent.py::test_slash_status_returns_without_llm_call`, `tests/core/test_agent.py::test_slash_history_returns_without_llm_call`, `tests/core/test_agent.py::test_slash_remember_returns_without_llm_call` |
+| Owner-only all slash commands | `tests/core/test_agent.py::test_slash_help_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_new_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_status_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_history_denied_for_non_owner`, `tests/core/test_agent.py::test_slash_remember_denied_for_non_owner` |
+| `/status` stable response schema | `tests/core/test_agent.py::test_slash_status_response_contract` |
+| `/history` informational-only behavior | `tests/core/test_agent.py::test_slash_history_returns_informational_guidance_without_llm_call` |
+| Matrix sender provenance for slash auth | `tests/core/test_agent.py::test_slash_matrix_owner_allowed_via_metadata_sender`, `tests/core/test_agent.py::test_slash_matrix_non_owner_denied_via_metadata_sender` |
+| Missing attribution => deterministic deny | `tests/core/test_agent.py::test_slash_matrix_missing_sender_metadata_denied` |
+| `/remember` no lost updates for concurrent slash calls | `tests/core/test_agent.py::test_slash_remember_concurrent_calls_preserve_both_notes` |
+| Cross-channel parity of slash behavior | `tests/adapters/test_channel_loops.py::test_channel_loop_forwards_slash_messages_channel_agnostic` |
+| Existing `/help` + `/new` behavior for owner unchanged | existing slash tests in `tests/core/test_agent.py` with owner sender + parser regression tests |
+
+### Task 1: Add failing parser tests (including validation and command metadata)
+
+**Files:**
+- Create: `tests/core/test_slash_commands.py`
+- Modify: `squidbot/core/slash_commands.py` (later task)
+
+**Step 1: Write RED tests for parser behavior**
+
+```python
+from squidbot.core.slash_commands import handle_slash_command
+
+
+def test_slash_status_sets_action() -> None:
+    result = handle_slash_command("/status")
+    assert result.handled is True
+    assert result.action == "status"
+
+
+def test_slash_history_is_informational() -> None:
+    result = handle_slash_command("/history")
+    assert result.handled is True
+    assert result.action == "history"
+    assert result.is_error is False
+
+
+def test_slash_remember_requires_argument() -> None:
+    result = handle_slash_command("/remember   ")
+    assert result.handled is True
+    assert result.is_error is True
+    assert result.response_text == "Usage: /remember <text>"
+```
+
+**Step 2: Run RED tests**
+
+Run: `uv run pytest tests/core/test_slash_commands.py -v`
+Expected: FAIL because metadata fields and command branches do not exist yet.
+
+**Step 3: Commit RED tests**
+
+```bash
+git add tests/core/test_slash_commands.py
+git commit -m "test(core): add slash parser red tests for command pack"
+```
+
+### Task 2: Implement slash parser extensions and help text updates
+
+**Files:**
+- Modify: `squidbot/core/slash_commands.py`
+- Test: `tests/core/test_slash_commands.py`
+
+**Step 1: Extend `SlashCommandResult` contract**
+
+```python
+@dataclass(frozen=True)
+class SlashCommandResult:
+    handled: bool
+    response_text: str = ""
+    reset_requested: bool = False
+    action: str | None = None
+    argument: str | None = None
+    is_error: bool = False
+```
+
+**Step 2: Parse command + argument and add branches**
+
+```python
+cmd, arg = _split_slash_input(stripped)
+
+if cmd == "/status":
+    return SlashCommandResult(handled=True, action="status")
+if cmd == "/history":
+    return SlashCommandResult(handled=True, action="history")
+if cmd == "/remember":
+    if not arg:
+        return SlashCommandResult(handled=True, is_error=True, response_text="Usage: /remember <text>")
+    return SlashCommandResult(handled=True, action="remember", argument=arg)
+```
+
+**Step 3: Update `HELP_TEXT` with all commands**
+
+**Step 4: Run parser tests to GREEN**
+
+Run: `uv run pytest tests/core/test_slash_commands.py -v`
+Expected: PASS.
+
+**Step 5: Commit parser changes**
+
+```bash
+git add squidbot/core/slash_commands.py tests/core/test_slash_commands.py
+git commit -m "feat(core): extend slash parser with command metadata"
+```
+
+### Task 3: Add failing core tests for authorization and `/status` contract
+
+**Files:**
+- Modify: `tests/core/test_agent.py`
+- Modify: `squidbot/core/memory.py` (later task)
+- Modify: `squidbot/core/agent.py` (later task)
+
+**Step 1: Write RED tests for owner-only behavior**
+
+```python
+async def test_slash_history_denied_for_non_owner(storage):
+    memory = MemoryManager(storage=storage, owner_aliases=[OwnerAliasEntry(address="owner", channel="cli")])
+    session = Session(channel="cli", sender_id="guest")
+    ...
+    await loop.run(session, "/history token", channel)
+    assert channel.sent[0].text == "Access denied: slash commands are only available to the owner."
+```
+
+```python
+async def test_slash_help_denied_for_non_owner(storage): ...
+async def test_slash_new_denied_for_non_owner(storage): ...
+async def test_slash_status_denied_for_non_owner(storage): ...
+async def test_slash_remember_denied_for_non_owner(storage): ...
+```
+
+**Step 2: Write RED Matrix sender-provenance tests**
+
+```python
+async def test_slash_matrix_owner_allowed_via_metadata_sender(storage):
+    # session.sender_id is room-like, owner identity comes from metadata sender
+    session = Session(channel="matrix", sender_id="!room:example.org")
+    metadata = {"matrix_sender_id": "@owner:example.org"}
+    ...
+
+
+async def test_slash_matrix_non_owner_denied_via_metadata_sender(storage): ...
+
+
+async def test_slash_matrix_missing_sender_metadata_denied(storage): ...
+```
+
+**Step 3: Write RED test for exact `/status` schema**
+
+```python
+async def test_slash_status_response_contract(storage, memory):
+    await loop.run(SESSION, "/status", channel)
+    assert channel.sent[0].text.splitlines() == [
+        "Current session status:",
+        f"- channel: {SESSION.channel}",
+        f"- physical_session: {SESSION.id}",
+        f"- logical_session: {SESSION.id}",
+        "- next_turn_history_backfill: true",
+    ]
+```
+
+**Step 4: Add RED test for CLI always-allowed policy**
+
+```python
+async def test_slash_cli_always_allowed(storage):
+    memory = MemoryManager(storage=storage, owner_aliases=[OwnerAliasEntry(address="someone", channel="email")])
+    session = Session(channel="cli", sender_id="random-cli-user")
+    ...
+    await loop.run(session, "/help", channel)
+    assert "Available commands" in channel.sent[0].text
+```
+
+**Step 5: Run RED tests**
+
+Run: `uv run pytest tests/core/test_agent.py -v`
+Expected: FAIL on missing authorization and exact status formatting.
+
+**Step 6: Commit RED tests**
+
+```bash
+git add tests/core/test_agent.py
+git commit -m "test(core): add slash auth and status contract red tests"
+```
+
+### Task 4: Implement owner authorization and `/status` contract
+
+**Files:**
+- Modify: `squidbot/core/memory.py`
+- Modify: `squidbot/core/agent.py`
+- Test: `tests/core/test_agent.py`
+
+**Step 1: Add public owner-check method on `MemoryManager` with CLI allow policy**
+
+```python
+def is_owner_sender(self, sender_id: str | None, channel: str) -> bool:
+    if channel == "cli":
+        return True
+    if sender_id is None:
+        return False
+    return self._is_owner(sender_id, channel)
+```
+
+**Step 2: Add channel-aware sender resolver helper in `AgentLoop`**
+
+```python
+def _resolve_slash_actor_sender(
+    self,
+    session: Session,
+    user_sender_id: str | None,
+    outbound_metadata: dict[str, Any] | None,
+) -> str | None:
+    if session.channel == "matrix":
+        sender = (outbound_metadata or {}).get("matrix_sender_id")
+        return sender if isinstance(sender, str) and sender else None
+    if user_sender_id:
+        return user_sender_id
+    return session.sender_id
+```
+
+**Step 3: Add slash authorization guard in `AgentLoop` for all slash commands**
+
+```python
+actor_sender = self._resolve_slash_actor_sender(session, user_sender_id, outbound_metadata)
+if slash_result.handled and not self._memory.is_owner_sender(actor_sender, session.channel):
+    await channel.send(
+        OutboundMessage(..., text="Access denied: slash commands are only available to the owner.")
+    )
+    return
+```
+
+**Step 4: Implement fixed `/status` formatter**
+
+```python
+def _build_status_text(self, session: Session) -> str:
+    ...
+```
+
+**Step 5: Run focused tests to GREEN**
+
+Run: `uv run pytest tests/core/test_agent.py -k "slash and (status or denied or cli_always or matrix)" -v`
+Expected: PASS.
+
+**Step 6: Commit implementation**
+
+```bash
+git add squidbot/core/memory.py squidbot/core/agent.py tests/core/test_agent.py
+git commit -m "feat(core): enforce slash auth and status response contract"
+```
+
+### Task 5: Add failing tests for `/history` informational behavior
+
+**Files:**
+- Modify: `tests/core/test_agent.py`
+- Modify: `squidbot/core/agent.py` (later task)
+
+**Step 1: Add RED tests for informational `/history`**
+
+```python
+async def test_slash_history_returns_informational_guidance_without_llm_call(storage, memory):
+    ...
+    await loop.run(SESSION, "/history", channel)
+    assert "informational" in channel.sent[0].text.lower()
+    assert "search_history" in channel.sent[0].text
+
+
+async def test_slash_history_ignores_extra_arguments(storage, memory):
+    ...
+    await loop.run(SESSION, "/history project x", channel)
+    assert "search_history" in channel.sent[0].text
+```
+
+**Step 2: Run RED tests**
+
+Run: `uv run pytest tests/core/test_agent.py -k "slash and history" -v`
+Expected: FAIL because `/history` action is not implemented yet.
+
+**Step 3: Commit RED tests**
+
+```bash
+git add tests/core/test_agent.py
+git commit -m "test(core): add informational slash history red tests"
+```
+
+### Task 6: Implement informational slash `/history` dispatch
+
+**Files:**
+- Modify: `squidbot/core/agent.py`
+- Modify: `tests/core/test_agent.py`
+
+**Step 1: Add deterministic informational text for `/history` in `AgentLoop`**
+
+```python
+def _build_history_info_text(self) -> str:
+    return (
+        "History command is informational only. "
+        "To recall past details, ask me to run search_history with your query."
+    )
+```
+
+**Step 2: Dispatch `/history` action without tool calls**
+
+```python
+if slash_result.action == "history":
+    await channel.send(OutboundMessage(session=session, text=self._build_history_info_text(), ...))
+    return
+```
+
+**Step 3: Add assertion that `/history` does not require `search_history` tool registration**
+
+**Step 4: Run focused tests to GREEN**
+
+Run:
+- `uv run pytest tests/core/test_agent.py -k "slash and history" -v`
+
+Expected: PASS.
+
+**Step 5: Commit implementation**
+
+```bash
+git add squidbot/core/agent.py tests/core/test_agent.py
+git commit -m "feat(core): add informational slash history command"
+```
+
+### Task 7: Add failing `/remember` concurrency and error-path tests
+
+**Files:**
+- Modify: `tests/core/test_agent.py`
+- Modify: `squidbot/core/agent.py` (later task)
+
+**Step 1: Add RED concurrency test**
+
+```python
+async def test_slash_remember_concurrent_calls_preserve_both_notes(storage, memory):
+    await asyncio.gather(
+        loop.run(owner_session, "/remember note-one", channel),
+        loop.run(owner_session, "/remember note-two", channel),
+    )
+    saved = await storage.load_global_memory()
+    assert "note-one" in saved
+    assert "note-two" in saved
+```
+
+**Step 2: Add RED failure-path tests for `/remember`**
+
+- missing `memory_write` tool
+- tool raises exception
+- tool returns `ToolResult(is_error=True)`
+
+**Step 3: Run RED tests**
+
+Run: `uv run pytest tests/core/test_agent.py -k "slash and remember" -v`
+Expected: FAIL due to no lock and incomplete error handling.
+
+**Step 4: Commit RED tests**
+
+```bash
+git add tests/core/test_agent.py
+git commit -m "test(core): add slash remember concurrency red tests"
+```
+
+### Task 8: Implement serialized `/remember` workflow
+
+**Files:**
+- Modify: `squidbot/core/agent.py`
+- Modify: `squidbot/core/memory.py`
+- Test: `tests/core/test_agent.py`
+
+**Step 1: Add shared async lock in `AgentLoop`**
+
+```python
+self._remember_lock = asyncio.Lock()
+```
+
+**Step 2: Add helper to read global memory text through `MemoryManager`**
+
+```python
+async def load_global_memory_text(self) -> str:
+    return await self._storage.load_global_memory()
+```
+
+**Step 3: Serialize `/remember` read-modify-write**
+
+```python
+async with self._remember_lock:
+    existing = await self._memory.load_global_memory_text()
+    merged = _append_memory_note(existing, note)
+    result = await memory_tool.execute(content=merged)
+```
+
+**Step 4: Narrow and enforce guarantee scope explicitly**
+
+- Guarantee applies to concurrent slash `/remember` calls only.
+- Non-slash `memory_write` write ordering remains existing behavior.
+- Ensure docs and test names reflect slash-scoped concurrency guarantee.
+
+**Step 5: Normalize slash error handling for exceptions and error results**
+
+**Step 6: Run focused tests to GREEN**
+
+Run: `uv run pytest tests/core/test_agent.py -k "slash and remember" -v`
+Expected: PASS.
+
+**Step 7: Commit implementation**
+
+```bash
+git add squidbot/core/agent.py squidbot/core/memory.py tests/core/test_agent.py
+git commit -m "fix(core): serialize slash remember writes to avoid races"
+```
+
+### Task 9: Add channel-loop parity test for slash forwarding
+
+**Files:**
+- Modify: `tests/adapters/test_channel_loops.py`
+
+**Step 1: Add parity-focused test**
+
+```python
+async def test_channel_loop_forwards_slash_messages_channel_agnostic():
+    # run _channel_loop twice with different channel/session labels (matrix/email)
+    # assert loop.run receives slash text unchanged in both cases
+```
+
+**Step 2: Run targeted parity tests**
+
+Run: `uv run pytest tests/adapters/test_channel_loops.py -v`
+Expected: PASS.
+
+**Step 3: Commit parity test**
+
+```bash
+git add tests/adapters/test_channel_loops.py
+git commit -m "test(adapters): verify slash forwarding parity across channel loops"
+```
+
+### Task 10: Update docs and run full verification gates
+
+**Files:**
+- Modify: `README.md`
+- Verify: `docs/plans/2026-03-03-slash-command-pack-design.md`
+- Verify: `docs/plans/2026-03-03-slash-command-pack-implementation-plan.md`
+
+**Step 1: Update README slash command list and owner-only notes**
+
+```markdown
+- Slash commands are owner-only (`/help`, `/new`, `/status`, `/history`, `/remember`)
+- `/status` — show current logical session status
+- `/history` — informational guidance for explicit history recall
+- `/remember <text>` — append memory note
+```
+
+**Step 2: Run full quality gates**
+
+Run:
+- `uv run ruff check .`
+- `uv run ruff format . --check`
+- `uv run mypy squidbot/`
+- `uv run pytest`
+
+Additional verification:
+- confirm non-slash Matrix mention/allowlist behavior remains unchanged by slash auth layer
+  (`uv run pytest tests/adapters/channels/test_matrix.py -k "mention or allowlist" -v`)
+
+Expected: all PASS.
+
+**Step 3: Final docs commit**
+
+```bash
+git add README.md docs/plans/2026-03-03-slash-command-pack-design.md docs/plans/2026-03-03-slash-command-pack-implementation-plan.md
+git commit -m "docs: harden slash command pack plan with auth and race controls"
+```

--- a/squidbot/core/agent.py
+++ b/squidbot/core/agent.py
@@ -104,6 +104,7 @@ class AgentLoop:
         self._session_generation: OrderedDict[str, int] = OrderedDict()
         self._session_backfill_next_turn: dict[str, bool] = {}
         self._max_tracked_session_generations = MAX_TRACKED_SESSION_GENERATIONS
+        self._remember_lock = asyncio.Lock()
 
     def _get_session_generation(self, session_id: str) -> int:
         """Return session generation while refreshing recency order."""
@@ -144,6 +145,73 @@ class AgentLoop:
             for tool in extra_tool_map.values()
         ]
         return tool_definitions, extra_tool_map
+
+    def _build_status_text(self, session: Session) -> str:
+        """Return the deterministic slash status payload."""
+        logical_session = self._effective_session_id(session)
+        next_turn_backfill = self._session_backfill_next_turn.get(session.id, True)
+        backfill_text = "true" if next_turn_backfill else "false"
+        return (
+            "Current session status:\n"
+            f"- channel: {session.channel}\n"
+            f"- physical_session: {session.id}\n"
+            f"- logical_session: {logical_session}\n"
+            f"- next_turn_history_backfill: {backfill_text}"
+        )
+
+    def _build_history_info_text(self) -> str:
+        """Return informational text for /history without retrieval."""
+        return (
+            "History command is informational only. "
+            "To recall past details, ask me to run search_history with your query."
+        )
+
+    def _resolve_slash_actor_sender(
+        self,
+        session: Session,
+        user_sender_id: str | None,
+        outbound_metadata: dict[str, Any] | None,
+    ) -> str | None:
+        """Return sender identity used for slash authorization checks."""
+        if session.channel == "matrix":
+            sender = (outbound_metadata or {}).get("matrix_sender_id")
+            if isinstance(sender, str) and sender:
+                return sender
+            return None
+        if user_sender_id is not None:
+            return user_sender_id
+        return session.sender_id
+
+    @staticmethod
+    def _append_memory_note(existing: str, note: str) -> str:
+        """Append a single markdown bullet line to memory content."""
+        note_line = f"- {note.strip()}"
+        if not existing.strip():
+            return note_line
+        return f"{existing.rstrip()}\n{note_line}"
+
+    async def _run_slash_remember(
+        self,
+        note: str,
+        extra_tools: Sequence[ToolPort] | None,
+    ) -> str:
+        """Execute /remember by merging and writing global memory."""
+        extra_tool_map = {tool.name: tool for tool in (extra_tools or [])}
+        memory_tool = extra_tool_map.get("memory_write") or self._registry.get("memory_write")
+        if memory_tool is None:
+            return "Error: /remember unavailable (memory_write tool not configured)."
+
+        try:
+            async with self._remember_lock:
+                existing = await self._memory.load_global_memory_text()
+                merged = self._append_memory_note(existing, note)
+                result = await memory_tool.execute(content=merged)
+        except Exception as exc:  # noqa: BLE001
+            return f"Error: {exc}"
+
+        if result.is_error:
+            return result.content
+        return result.content
 
     async def _run_llm_stream(
         self,
@@ -381,15 +449,43 @@ class AgentLoop:
         if isinstance(user_message, str):
             slash_result = handle_slash_command(user_message)
             if slash_result.handled:
+                actor_sender = self._resolve_slash_actor_sender(
+                    session,
+                    user_sender_id,
+                    outbound_metadata,
+                )
+                if not self._memory.is_owner_sender(actor_sender, session.channel):
+                    await channel.send(
+                        OutboundMessage(
+                            session=session,
+                            text="Access denied: slash commands are only available to the owner.",
+                            metadata=outbound_metadata or {},
+                        )
+                    )
+                    return
+
                 if slash_result.reset_requested:
                     next_generation = self._get_session_generation(session.id) + 1
                     self._set_session_generation(session.id, next_generation)
                     # /new starts a fresh logical session without automatic history backfill.
                     self._session_backfill_next_turn[session.id] = False
+
+                slash_text = slash_result.response_text
+                if slash_result.action == "status":
+                    slash_text = self._build_status_text(session)
+                if slash_result.action == "history":
+                    slash_text = self._build_history_info_text()
+                if slash_result.action == "remember":
+                    remember_note = slash_result.argument or ""
+                    if not remember_note:
+                        slash_text = "Usage: /remember <text>"
+                    else:
+                        slash_text = await self._run_slash_remember(remember_note, extra_tools)
+
                 await channel.send(
                     OutboundMessage(
                         session=session,
-                        text=slash_result.response_text,
+                        text=slash_text,
                         metadata=outbound_metadata or {},
                     )
                 )

--- a/squidbot/core/agent.py
+++ b/squidbot/core/agent.py
@@ -146,24 +146,22 @@ class AgentLoop:
         ]
         return tool_definitions, extra_tool_map
 
-    def _build_status_text(self, session: Session) -> str:
+    async def _build_status_text(self, session: Session) -> str:
         """Return the deterministic slash status payload."""
         logical_session = self._effective_session_id(session)
         next_turn_backfill = self._session_backfill_next_turn.get(session.id, True)
         backfill_text = "true" if next_turn_backfill else "false"
+        history_count = await self._memory.count_session_history(
+            session=session,
+            session_id=logical_session,
+        )
         return (
             "Current session status:\n"
             f"- channel: {session.channel}\n"
             f"- physical_session: {session.id}\n"
             f"- logical_session: {logical_session}\n"
-            f"- next_turn_history_backfill: {backfill_text}"
-        )
-
-    def _build_history_info_text(self) -> str:
-        """Return informational text for /history without retrieval."""
-        return (
-            "History command is informational only. "
-            "To recall past details, ask me to run search_history with your query."
+            f"- next_turn_history_backfill: {backfill_text}\n"
+            f"- history_messages: {history_count}"
         )
 
     def _resolve_slash_actor_sender(
@@ -472,9 +470,7 @@ class AgentLoop:
 
                 slash_text = slash_result.response_text
                 if slash_result.action == "status":
-                    slash_text = self._build_status_text(session)
-                if slash_result.action == "history":
-                    slash_text = self._build_history_info_text()
+                    slash_text = await self._build_status_text(session)
                 if slash_result.action == "remember":
                     remember_note = slash_result.argument or ""
                     if not remember_note:

--- a/squidbot/core/agent.py
+++ b/squidbot/core/agent.py
@@ -34,6 +34,12 @@ from squidbot.core.slash_commands import handle_slash_command
 MAX_TOOL_ROUNDS = 20
 MAX_TRACKED_SESSION_GENERATIONS = 10_000
 MAX_LOG_TOKEN_LEN = 128
+SLASH_ACCESS_DENIED_TEXT = "Access denied: slash commands are only available to the owner."
+SLASH_STATUS_BUILD_ERROR_TEXT = "Error: unable to build session status right now."
+SLASH_REMEMBER_USAGE_TEXT = "Usage: /remember <text>"
+SLASH_REMEMBER_UNAVAILABLE_TEXT = "Error: /remember unavailable (memory_write tool not configured)."
+SLASH_REMEMBER_INVALID_RESULT_TEXT = "Error: memory_write returned an invalid result."
+SLASH_ERROR_PREFIX = "Error: "
 
 
 def _sanitize_log_value(value: str) -> str:
@@ -197,7 +203,7 @@ class AgentLoop:
         extra_tool_map = {tool.name: tool for tool in (extra_tools or [])}
         memory_tool = extra_tool_map.get("memory_write") or self._registry.get("memory_write")
         if memory_tool is None:
-            return "Error: /remember unavailable (memory_write tool not configured)."
+            return SLASH_REMEMBER_UNAVAILABLE_TEXT
 
         try:
             async with self._remember_lock:
@@ -205,10 +211,10 @@ class AgentLoop:
                 merged = self._append_memory_note(existing, note)
                 result = await memory_tool.execute(content=merged)
                 if not isinstance(result, ToolResult):
-                    return "Error: memory_write returned an invalid result."
+                    return SLASH_REMEMBER_INVALID_RESULT_TEXT
                 return result.content
         except Exception as exc:  # noqa: BLE001
-            return f"Error: {exc}"
+            return f"{SLASH_ERROR_PREFIX}{exc}"
 
     async def _run_llm_stream(
         self,
@@ -455,7 +461,7 @@ class AgentLoop:
                     await channel.send(
                         OutboundMessage(
                             session=session,
-                            text="Access denied: slash commands are only available to the owner.",
+                            text=SLASH_ACCESS_DENIED_TEXT,
                             metadata=outbound_metadata or {},
                         )
                     )
@@ -477,11 +483,11 @@ class AgentLoop:
                             session.id,
                             exc,
                         )
-                        slash_text = "Error: unable to build session status right now."
+                        slash_text = SLASH_STATUS_BUILD_ERROR_TEXT
                 if slash_result.action == "remember":
                     remember_note = slash_result.argument or ""
                     if not remember_note:
-                        slash_text = "Usage: /remember <text>"
+                        slash_text = SLASH_REMEMBER_USAGE_TEXT
                     else:
                         slash_text = await self._run_slash_remember(remember_note, extra_tools)
 

--- a/squidbot/core/agent.py
+++ b/squidbot/core/agent.py
@@ -204,12 +204,11 @@ class AgentLoop:
                 existing = await self._memory.load_global_memory_text()
                 merged = self._append_memory_note(existing, note)
                 result = await memory_tool.execute(content=merged)
+                if not isinstance(result, ToolResult):
+                    return "Error: memory_write returned an invalid result."
+                return result.content
         except Exception as exc:  # noqa: BLE001
             return f"Error: {exc}"
-
-        if result.is_error:
-            return result.content
-        return result.content
 
     async def _run_llm_stream(
         self,
@@ -470,7 +469,15 @@ class AgentLoop:
 
                 slash_text = slash_result.response_text
                 if slash_result.action == "status":
-                    slash_text = await self._build_status_text(session)
+                    try:
+                        slash_text = await self._build_status_text(session)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent.run: /status failed while building status for session={}: {}",
+                            session.id,
+                            exc,
+                        )
+                        slash_text = "Error: unable to build session status right now."
                 if slash_result.action == "remember":
                     remember_note = slash_result.argument or ""
                     if not remember_note:

--- a/squidbot/core/memory.py
+++ b/squidbot/core/memory.py
@@ -92,6 +92,29 @@ class MemoryManager:
             return True
         return sender_id in self._unscoped_aliases
 
+    def is_owner_sender(self, sender_id: str | None, channel: str) -> bool:
+        """Return True when sender is authorized as owner for a channel.
+
+        CLI is always authorized because physical host access implies owner control.
+        For non-CLI channels, owner aliases are required.
+
+        Args:
+            sender_id: Sender identifier resolved by the channel loop.
+            channel: Channel name for scoped alias matching.
+
+        Returns:
+            True when the sender is treated as owner for policy checks.
+        """
+        if channel == "cli":
+            return True
+        if sender_id is None:
+            return False
+        return self._is_owner(sender_id, channel)
+
+    async def load_global_memory_text(self) -> str:
+        """Return current global memory document text."""
+        return await self._storage.load_global_memory()
+
     def _label_message(self, msg: Message) -> Message:
         """
         Return a copy of msg with a channel/sender label prepended to content.

--- a/squidbot/core/memory.py
+++ b/squidbot/core/memory.py
@@ -112,7 +112,11 @@ class MemoryManager:
         return self._is_owner(sender_id, channel)
 
     async def load_global_memory_text(self) -> str:
-        """Return current global memory document text."""
+        """Load the current global memory document text.
+
+        Returns:
+            Current content of the global memory document.
+        """
         return await self._storage.load_global_memory()
 
     async def count_session_history(self, *, session: Session, session_id: str) -> int:

--- a/squidbot/core/memory.py
+++ b/squidbot/core/memory.py
@@ -115,6 +115,24 @@ class MemoryManager:
         """Return current global memory document text."""
         return await self._storage.load_global_memory()
 
+    async def count_session_history(self, *, session: Session, session_id: str) -> int:
+        """Return number of persisted messages for a logical session.
+
+        Args:
+            session: Physical session used for legacy matching fallback.
+            session_id: Logical session identifier.
+
+        Returns:
+            Count of history rows that belong to the logical session.
+        """
+        history = await self._storage.load_history(last_n=None)
+        filtered = self._filter_history_for_session(
+            history,
+            target_session_id=session_id,
+            fallback_session=session,
+        )
+        return len(filtered)
+
     def _label_message(self, msg: Message) -> Message:
         """
         Return a copy of msg with a channel/sender label prepended to content.

--- a/squidbot/core/slash_commands.py
+++ b/squidbot/core/slash_commands.py
@@ -17,9 +17,27 @@ class SlashCommandResult:
     handled: bool
     response_text: str = ""
     reset_requested: bool = False
+    action: str | None = None
+    argument: str | None = None
+    is_error: bool = False
 
 
-HELP_TEXT = "Available commands:\n- /help: show this help\n- /new: start a new conversation context"
+HELP_TEXT = (
+    "Available commands:\n"
+    "- /help: show this help\n"
+    "- /new: start a new conversation context\n"
+    "- /status: show current session status\n"
+    "- /history: show history recall guidance\n"
+    "- /remember <text>: append a memory note"
+)
+
+
+def _split_command_and_argument(stripped: str) -> tuple[str, str]:
+    """Return lower-cased command and optional argument string."""
+    parts = stripped.split(maxsplit=1)
+    cmd = parts[0].lower()
+    argument = parts[1].strip() if len(parts) > 1 else ""
+    return cmd, argument
 
 
 def handle_slash_command(text: str) -> SlashCommandResult:
@@ -35,7 +53,7 @@ def handle_slash_command(text: str) -> SlashCommandResult:
     if not stripped.startswith("/"):
         return SlashCommandResult(handled=False)
 
-    cmd = stripped.split(maxsplit=1)[0].lower()
+    cmd, argument = _split_command_and_argument(stripped)
     if cmd == "/help":
         return SlashCommandResult(handled=True, response_text=HELP_TEXT)
     if cmd == "/new":
@@ -44,8 +62,21 @@ def handle_slash_command(text: str) -> SlashCommandResult:
             response_text="Started a new conversation context for this session.",
             reset_requested=True,
         )
+    if cmd == "/status":
+        return SlashCommandResult(handled=True, action="status")
+    if cmd == "/history":
+        return SlashCommandResult(handled=True, action="history")
+    if cmd == "/remember":
+        if not argument:
+            return SlashCommandResult(
+                handled=True,
+                response_text="Usage: /remember <text>",
+                is_error=True,
+            )
+        return SlashCommandResult(handled=True, action="remember", argument=argument)
 
     return SlashCommandResult(
         handled=True,
         response_text=f"Unknown command: {cmd}. Use /help for available commands.",
+        is_error=True,
     )

--- a/squidbot/core/slash_commands.py
+++ b/squidbot/core/slash_commands.py
@@ -27,7 +27,6 @@ HELP_TEXT = (
     "- /help: show this help\n"
     "- /new: start a new conversation context\n"
     "- /status: show current session status\n"
-    "- /history: show history recall guidance\n"
     "- /remember <text>: append a memory note"
 )
 
@@ -64,8 +63,6 @@ def handle_slash_command(text: str) -> SlashCommandResult:
         )
     if cmd == "/status":
         return SlashCommandResult(handled=True, action="status")
-    if cmd == "/history":
-        return SlashCommandResult(handled=True, action="history")
     if cmd == "/remember":
         if not argument:
             return SlashCommandResult(

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 from loguru import logger
 
+from squidbot.config.schema import OwnerAliasEntry
 from squidbot.core.agent import AgentLoop
 from squidbot.core.memory import MemoryManager
 from squidbot.core.models import (
@@ -145,6 +146,29 @@ class SensitiveEchoTool:
             tool_call_id="",
             content=f"api_key={api_key} password={password}",
         )
+
+
+class MemoryWriteToolDouble:
+    name = "memory_write"
+    description = "Writes memory content"
+    parameters = {
+        "type": "object",
+        "properties": {"content": {"type": "string"}},
+        "required": ["content"],
+    }
+    concurrent = False
+
+    def __init__(self, storage: InMemoryStorage) -> None:
+        self._storage = storage
+        self.last_content: str | None = None
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        content = kwargs.get("content")
+        if not isinstance(content, str):
+            return ToolResult(tool_call_id="", content="Error: content is required", is_error=True)
+        self.last_content = content
+        await self._storage.save_global_memory(content)
+        return ToolResult(tool_call_id="", content="Memory updated successfully.")
 
 
 def _log_contains_with_fields(log_output: str, event_name: str, required_fields: list[str]) -> bool:
@@ -849,6 +873,180 @@ async def test_unknown_slash_command_returns_help_hint_without_llm_call(storage,
     assert len(channel.sent) == 1
     assert "unknown command" in channel.sent[0].text.lower()
     assert "/help" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_status_returns_contract_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/status", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text.startswith("Current session status:\n")
+    assert "- channel: cli" in channel.sent[0].text
+    assert "- physical_session:" in channel.sent[0].text
+    assert "- logical_session:" in channel.sent[0].text
+    assert "- next_turn_history_backfill: true" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_history_returns_informational_text_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/history anything", channel)
+
+    assert len(channel.sent) == 1
+    assert "informational only" in channel.sent[0].text.lower()
+    assert "search_history" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_remember_updates_memory_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    registry = ToolRegistry()
+    tool = MemoryWriteToolDouble(storage)
+    registry.register(tool)
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=registry,
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/remember buy milk", channel)
+
+    assert len(channel.sent) == 1
+    assert "memory updated" in channel.sent[0].text.lower()
+    assert tool.last_content is not None
+    assert "buy milk" in tool.last_content
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_remember_requires_text_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    registry = ToolRegistry()
+    registry.register(MemoryWriteToolDouble(storage))
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=registry,
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/remember  ", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Usage: /remember <text>"
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_commands_denied_for_non_cli_non_owner(storage):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    memory = MemoryManager(
+        storage=storage,
+        owner_aliases=[OwnerAliasEntry(address="owner@example.com", channel="email")],
+    )
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+    email_session = Session(channel="email", sender_id="guest@example.com")
+
+    await loop.run(email_session, "/help", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Access denied: slash commands are only available to the owner."
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_commands_always_allowed_on_cli(storage):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    memory = MemoryManager(
+        storage=storage,
+        owner_aliases=[OwnerAliasEntry(address="owner@example.com", channel="email")],
+    )
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+    cli_session = Session(channel="cli", sender_id="random-cli-user")
+
+    await loop.run(cli_session, "/help", channel)
+
+    assert len(channel.sent) == 1
+    assert "Available commands" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_matrix_auth_uses_metadata_sender(storage):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    memory = MemoryManager(
+        storage=storage,
+        owner_aliases=[OwnerAliasEntry(address="@owner:example.org", channel="matrix")],
+    )
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+    matrix_session = Session(channel="matrix", sender_id="!room:example.org")
+
+    await loop.run(
+        matrix_session,
+        "/help",
+        channel,
+        user_sender_id="@owner:example.org",
+        outbound_metadata={"matrix_sender_id": "@owner:example.org"},
+    )
+
+    assert len(channel.sent) == 1
+    assert "Available commands" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_matrix_missing_metadata_sender_is_denied(storage):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    memory = MemoryManager(
+        storage=storage,
+        owner_aliases=[OwnerAliasEntry(address="@owner:example.org", channel="matrix")],
+    )
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+    matrix_session = Session(channel="matrix", sender_id="!room:example.org")
+
+    await loop.run(matrix_session, "/help", channel, user_sender_id="@owner:example.org")
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Access denied: slash commands are only available to the owner."
     assert list(llm._responses) == ["from llm"]
 
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -149,6 +149,12 @@ class SensitiveEchoTool:
 
 
 class MemoryWriteToolDouble:
+    """Simple memory_write test double persisting text into InMemoryStorage.
+
+    The double mirrors the runtime tool contract used by slash `/remember`.
+    Tests inspect `last_content` to verify merge behavior and return text.
+    """
+
     name = "memory_write"
     description = "Writes memory content"
     parameters = {
@@ -159,16 +165,50 @@ class MemoryWriteToolDouble:
     concurrent = False
 
     def __init__(self, storage: InMemoryStorage) -> None:
+        """Initialize the test double.
+
+        Args:
+            storage: In-memory storage receiving memory updates.
+        """
         self._storage = storage
         self.last_content: str | None = None
 
     async def execute(self, **kwargs: Any) -> ToolResult:
+        """Write provided content into storage.
+
+        Args:
+            **kwargs: Tool arguments expected to include `content` as string.
+
+        Returns:
+            ToolResult with error when `content` is missing, otherwise success.
+        """
         content = kwargs.get("content")
         if not isinstance(content, str):
             return ToolResult(tool_call_id="", content="Error: content is required", is_error=True)
         self.last_content = content
         await self._storage.save_global_memory(content)
         return ToolResult(tool_call_id="", content="Memory updated successfully.")
+
+
+class RaisingMemoryWriteToolDouble(MemoryWriteToolDouble):
+    """memory_write double that raises to exercise error handling."""
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        raise RuntimeError("memory write failed")
+
+
+class ErrorMemoryWriteToolDouble(MemoryWriteToolDouble):
+    """memory_write double returning ToolResult with is_error=True."""
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        return ToolResult(tool_call_id="", content="Error: write rejected", is_error=True)
+
+
+class InvalidResultMemoryWriteToolDouble(MemoryWriteToolDouble):
+    """memory_write double returning invalid result shape."""
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return "not-a-tool-result"
 
 
 def _log_contains_with_fields(log_output: str, event_name: str, required_fields: list[str]) -> bool:
@@ -204,6 +244,11 @@ class PersistExchangeFailingMemory(MemoryManager):
         session_id: str,
     ) -> None:
         raise RuntimeError("persist failed")
+
+
+class CountSessionHistoryFailingMemory(MemoryManager):
+    async def count_session_history(self, *, session: Session, session_id: str) -> int:
+        raise RuntimeError("count failed")
 
 
 SESSION = Session(channel="cli", sender_id="local")
@@ -917,6 +962,24 @@ async def test_slash_status_includes_current_logical_history_size(storage, memor
     assert list(llm._responses) == []
 
 
+async def test_slash_status_returns_deterministic_error_when_history_count_fails(storage):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    failing_memory = CountSessionHistoryFailingMemory(storage=storage)
+    loop = AgentLoop(
+        llm=llm,
+        memory=failing_memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/status", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Error: unable to build session status right now."
+    assert list(llm._responses) == ["from llm"]
+
+
 async def test_slash_history_is_unknown_without_llm_call(storage, memory):
     llm = ScriptedLLM(["from llm"])
     channel = CollectingChannel()
@@ -973,6 +1036,80 @@ async def test_slash_remember_requires_text_without_llm_call(storage, memory):
 
     assert len(channel.sent) == 1
     assert channel.sent[0].text == "Usage: /remember <text>"
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_remember_missing_tool_returns_error_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/remember buy milk", channel)
+
+    assert len(channel.sent) == 1
+    assert "memory_write tool not configured" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_remember_tool_exception_returns_error_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    registry = ToolRegistry()
+    registry.register(RaisingMemoryWriteToolDouble(storage))
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=registry,
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/remember buy milk", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Error: memory write failed"
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_remember_tool_error_result_surfaces_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    registry = ToolRegistry()
+    registry.register(ErrorMemoryWriteToolDouble(storage))
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=registry,
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/remember buy milk", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Error: write rejected"
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_remember_invalid_result_shape_returns_error_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    registry = ToolRegistry()
+    registry.register(InvalidResultMemoryWriteToolDouble(storage))
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=registry,
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "/remember buy milk", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Error: memory_write returned an invalid result."
     assert list(llm._responses) == ["from llm"]
 
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -894,10 +894,30 @@ async def test_slash_status_returns_contract_without_llm_call(storage, memory):
     assert "- physical_session:" in channel.sent[0].text
     assert "- logical_session:" in channel.sent[0].text
     assert "- next_turn_history_backfill: true" in channel.sent[0].text
+    assert "- history_messages: 0" in channel.sent[0].text
     assert list(llm._responses) == ["from llm"]
 
 
-async def test_slash_history_returns_informational_text_without_llm_call(storage, memory):
+async def test_slash_status_includes_current_logical_history_size(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+    )
+
+    await loop.run(SESSION, "hello", channel)
+    await loop.run(SESSION, "/status", channel)
+
+    assert len(channel.sent) == 2
+    assert channel.sent[0].text == "from llm"
+    assert "- history_messages: 2" in channel.sent[1].text
+    assert list(llm._responses) == []
+
+
+async def test_slash_history_is_unknown_without_llm_call(storage, memory):
     llm = ScriptedLLM(["from llm"])
     channel = CollectingChannel()
     loop = AgentLoop(
@@ -910,8 +930,8 @@ async def test_slash_history_returns_informational_text_without_llm_call(storage
     await loop.run(SESSION, "/history anything", channel)
 
     assert len(channel.sent) == 1
-    assert "informational only" in channel.sent[0].text.lower()
-    assert "search_history" in channel.sent[0].text
+    assert "unknown command" in channel.sent[0].text.lower()
+    assert "/help" in channel.sent[0].text
     assert list(llm._responses) == ["from llm"]
 
 

--- a/tests/core/test_slash_commands.py
+++ b/tests/core/test_slash_commands.py
@@ -1,4 +1,9 @@
-"""Tests for core slash command parsing and dispatch metadata."""
+"""Unit tests for slash command parsing and parser metadata.
+
+These tests verify how raw slash input maps to `SlashCommandResult` fields such
+as `handled`, `action`, `argument`, and `is_error`. They lock down parser
+behavior so AgentLoop dispatch remains stable when command routing evolves.
+"""
 
 from __future__ import annotations
 

--- a/tests/core/test_slash_commands.py
+++ b/tests/core/test_slash_commands.py
@@ -1,0 +1,36 @@
+"""Tests for core slash command parsing and dispatch metadata."""
+
+from __future__ import annotations
+
+from squidbot.core.slash_commands import handle_slash_command
+
+
+def test_slash_status_sets_status_action() -> None:
+    result = handle_slash_command("/status")
+
+    assert result.handled is True
+    assert result.action == "status"
+
+
+def test_slash_history_is_informational_action() -> None:
+    result = handle_slash_command("/history")
+
+    assert result.handled is True
+    assert result.action == "history"
+    assert result.is_error is False
+
+
+def test_slash_remember_requires_text_argument() -> None:
+    result = handle_slash_command("/remember   ")
+
+    assert result.handled is True
+    assert result.is_error is True
+    assert result.response_text == "Usage: /remember <text>"
+
+
+def test_slash_remember_sets_argument_when_present() -> None:
+    result = handle_slash_command("/remember buy milk")
+
+    assert result.handled is True
+    assert result.action == "remember"
+    assert result.argument == "buy milk"

--- a/tests/core/test_slash_commands.py
+++ b/tests/core/test_slash_commands.py
@@ -12,12 +12,13 @@ def test_slash_status_sets_status_action() -> None:
     assert result.action == "status"
 
 
-def test_slash_history_is_informational_action() -> None:
+def test_slash_history_is_unknown_command() -> None:
     result = handle_slash_command("/history")
 
     assert result.handled is True
-    assert result.action == "history"
-    assert result.is_error is False
+    assert result.action is None
+    assert result.is_error is True
+    assert "Unknown command: /history" in result.response_text
 
 
 def test_slash_remember_requires_text_argument() -> None:


### PR DESCRIPTION
## Summary
- add deterministic slash handlers for `/status`, `/history`, and `/remember <text>` while keeping `/help` and `/new`
- enforce owner-gated slash authorization for non-CLI channels, with CLI slash commands always allowed
- keep `/history` intentionally informational (YAGNI), and add `/remember` memory-write merge flow with tests
- document design + implementation plans and update README slash command reference

## Testing
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run mypy squidbot/`
- `uv run pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and plans with /status and /remember, owner-only notes for non-CLI channels, CLI-allowed clarification, and added Hexagonal architecture note.

* **New Features**
  * Added cross-channel slash commands: /status (deterministic session diagnostics) and /remember <text> (append persistent notes); owner-only on non-CLI channels.

* **Tests**
  * Added end-to-end and unit tests for parsing, authorization, /status contract, /remember flows, and memory-write error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->