### PR TITLE
feat(core): add session-scoped model and pool slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight personal AI assistant. Hexagonal architecture, multi-channel, mult
 - **Multi-model LLM pools** — named pools with ordered fallback; define providers, models, and pools independently
 - **Skills system** — on-demand skill loading, agent-created skills, hot-reload without restart
 - **Tools** — shell commands, file read/write/edit, web search, memory write, MCP servers, sub-agents (spawn)
-- **Slash commands** — cross-channel `/help`, `/new`, `/status`, and `/remember <text>`, handled in core without an LLM roundtrip (owner-only on non-CLI channels; always allowed on CLI)
+- **Slash commands** — cross-channel `/help`, `/new`, `/status`, `/model`, `/pool`, and `/remember <text>`, handled in core without an LLM roundtrip (owner-only on non-CLI channels; always allowed on CLI)
 - **Heartbeat** — proactive background checks on a configurable schedule and time window
 - **Cron scheduler** — recurring tasks with cron expressions or interval syntax
 - **Long-term memory** — manual-only: global `MEMORY.md` (agent-curated, cross-channel) plus global `history.jsonl`; use `search_history` for explicit recall of older details
@@ -295,6 +295,11 @@ Note: Slash commands are owner-only on non-CLI channels. CLI slash commands are 
 - `/help` — list available slash commands
 - `/new` — start a new logical conversation session for the current channel/session
 - `/status` — show current channel/logical session status
+- `/model` — show the last used model for the current logical session
+- `/pool` — show the active pool for the current logical session
+- `/pool list` — list configured pools
+- `/pool use <name>` — switch to a pool for the current logical session
+- `/pool reset` — reset the current logical session to the default pool
 - `/remember <text>` — append a memory note to global MEMORY.md
 
 ## Architecture

--- a/docs/plans/2026-03-04-model-pool-slash-commands-design.md
+++ b/docs/plans/2026-03-04-model-pool-slash-commands-design.md
@@ -1,0 +1,120 @@
+# Session-Scoped Model and Pool Slash Commands - Design
+
+## Problem
+
+Users currently cannot inspect or switch LLM pool/model behavior from chat. They must
+infer model routing from config and logs, which is slow during interactive use.
+
+## Goal
+
+Add deterministic slash commands for runtime visibility and temporary per-session pool
+switching, without writing config files and without adding persistent state.
+
+## Command Surface (YAGNI)
+
+- `/model`
+  - Show the currently active pool for the logical session.
+  - Show the last actually used model for that logical session.
+  - If no LLM request has happened in this logical session yet, return deterministic
+    text indicating no model has been used yet.
+- `/pool`
+  - Show active pool and whether it comes from default or session override.
+- `/pool list`
+  - List configured pool names.
+- `/pool use <name>`
+  - Set a temporary pool override for the current logical session.
+- `/pool reset`
+  - Remove logical-session override and return to default pool.
+
+No direct `/model use ...` command in v1. Model selection remains pool-driven.
+
+## Authorization
+
+Use existing slash authorization policy unchanged:
+
+- CLI: allowed.
+- Non-CLI: owner-only.
+
+No new auth model for this feature.
+
+## Architecture
+
+### 1) Slash parsing
+
+Extend `squidbot/core/slash_commands.py` with actions for `model` and `pool`, keeping
+argument parsing minimal and deterministic.
+
+### 2) AgentLoop runtime state
+
+Add session-scoped in-memory state keyed by logical session ID:
+
+- active pool override: `dict[str, str]`
+- last used model ID: `dict[str, str]`
+
+State is ephemeral and process-local.
+
+### 3) LLM resolver integration
+
+`AgentLoop` receives optional constructor dependencies:
+
+- `default_pool_name: str | None`
+- `resolve_llm: Callable[[str], LLMPort] | None`
+- `list_pool_names: Callable[[], list[str]] | None`
+
+For non-slash user turns, `AgentLoop` selects the effective pool (`override` or default),
+resolves the LLM adapter for that pool, and uses it for the turn.
+
+### 4) Last-used model tracking
+
+To support `/model` with real runtime information:
+
+- `OpenAIAdapter` exposes a lightweight method/property to return its model ID.
+- `PooledLLMAdapter` tracks the model ID of the adapter that actually succeeded on
+  the most recent call and exposes that value.
+- `AgentLoop` reads this introspection value after each successful LLM turn and stores
+  it in the logical-session map.
+
+This keeps core decoupled from concrete adapter types (duck typing via optional method).
+
+## Data Flow
+
+1. User sends message.
+2. Slash commands are parsed before any LLM call.
+3. If slash command:
+   - `/pool use` validates pool name against `list_pool_names`.
+   - `/pool reset` removes override for current logical session.
+   - `/pool` and `/model` render deterministic status text.
+4. If normal user message:
+   - determine logical session ID,
+   - resolve effective pool,
+   - resolve LLM adapter,
+   - run turn,
+   - capture last-used model for this logical session.
+
+## Error Handling
+
+- Missing pool name: `Usage: /pool use <name>`
+- Unknown pool: `Error: pool '<name>' not found.`
+- Pool switching unavailable (resolver not configured): deterministic error text.
+- `/model` before first LLM turn in logical session: deterministic info text.
+
+## Testing Strategy
+
+- Parser tests for `/model`, `/pool`, `/pool list`, `/pool use`, `/pool reset`.
+- Agent tests for:
+  - pool override set/read/reset behavior,
+  - override isolation across logical sessions (`/new`),
+  - `/model` no-usage and post-usage cases,
+  - unknown pool errors,
+  - behavior when resolver/list callback is unavailable.
+- Adapter tests for model introspection:
+  - `OpenAIAdapter` reports model ID,
+  - `PooledLLMAdapter` reports actually used fallback model.
+- Regression tests for existing slash commands.
+
+## Success Criteria
+
+- Users can inspect last-used model with `/model`.
+- Users can switch pool per logical session via `/pool use` and undo with `/pool reset`.
+- Changes are temporary and in-memory only.
+- Existing slash command behavior remains stable.

--- a/docs/plans/2026-03-04-model-pool-slash-commands-implementation-plan.md
+++ b/docs/plans/2026-03-04-model-pool-slash-commands-implementation-plan.md
@@ -1,0 +1,272 @@
+# Model/Pool Slash Commands Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add session-scoped slash commands to inspect the last used model and temporarily switch/reset LLM pools for the current logical session.
+
+**Architecture:** Extend slash parsing with `/model` and `/pool` actions, then execute these in `AgentLoop` before LLM calls. Track per-logical-session pool overrides and last-used model IDs in memory. Wire `AgentLoop` to resolve pools dynamically via gateway-provided callbacks while keeping behavior deterministic and owner-policy compatible.
+
+**Tech Stack:** Python 3.14, pytest, ruff, mypy --strict, existing OpenAIAdapter/PooledLLMAdapter and gateway `_resolve_llm` wiring.
+
+---
+
+### Task 1: Add failing parser tests for `/model` and `/pool`
+
+**Files:**
+- Modify: `tests/core/test_slash_commands.py`
+- Modify: `squidbot/core/slash_commands.py` (later task)
+
+**Step 1: Write the failing test**
+
+```python
+def test_slash_model_sets_action() -> None:
+    result = handle_slash_command("/model")
+    assert result.handled is True
+    assert result.action == "model"
+
+
+def test_slash_pool_sets_action_and_argument() -> None:
+    result = handle_slash_command("/pool use smart")
+    assert result.handled is True
+    assert result.action == "pool"
+    assert result.argument == "use smart"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_slash_commands.py -v`
+Expected: FAIL because `/model` and `/pool` are currently unknown commands.
+
+**Step 3: Write minimal implementation**
+
+```python
+if cmd == "/model":
+    return SlashCommandResult(handled=True, action="model")
+if cmd == "/pool":
+    return SlashCommandResult(handled=True, action="pool", argument=argument)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_slash_commands.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/core/test_slash_commands.py squidbot/core/slash_commands.py
+git commit -m "feat(core): parse model and pool slash commands"
+```
+
+### Task 2: Expose runtime model identity on LLM adapters
+
+**Files:**
+- Modify: `squidbot/adapters/llm/openai.py`
+- Modify: `squidbot/adapters/llm/pool.py`
+- Modify: `tests/adapters/llm/test_pool.py`
+- Modify: `tests/adapters/llm/test_openai_adapter.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_openai_adapter_reports_model_id() -> None:
+    adapter = OpenAIAdapter(api_base="https://api.test", api_key="k", model="claude-opus")
+    assert adapter.get_last_used_model_id() == "claude-opus"
+```
+
+```python
+async def test_pool_reports_last_successful_model_id() -> None:
+    a1 = _make_failing_adapter(RuntimeError("boom"))
+    a2 = _make_streaming_adapter(["ok"])
+    a2.get_last_used_model_id = lambda: "claude-haiku"
+    pool = PooledLLMAdapter([a1, a2])
+    await _collect(pool)
+    assert pool.get_last_used_model_id() == "claude-haiku"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/adapters/llm/test_pool.py tests/adapters/llm/test_openai_adapter.py -v`
+Expected: FAIL because adapters do not expose model identity yet.
+
+**Step 3: Write minimal implementation**
+
+```python
+class OpenAIAdapter:
+    def get_last_used_model_id(self) -> str:
+        return self._model
+```
+
+```python
+class PooledLLMAdapter:
+    self._last_used_model_id: str | None = None
+
+    def get_last_used_model_id(self) -> str | None:
+        return self._last_used_model_id
+```
+
+Update fallback path to set `_last_used_model_id` when an adapter succeeds.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/adapters/llm/test_pool.py tests/adapters/llm/test_openai_adapter.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add squidbot/adapters/llm/openai.py squidbot/adapters/llm/pool.py tests/adapters/llm/test_pool.py tests/adapters/llm/test_openai_adapter.py
+git commit -m "feat(llm): expose last-used model identity for runtime introspection"
+```
+
+### Task 3: Add failing AgentLoop tests for session-scoped pool/model state
+
+**Files:**
+- Modify: `tests/core/test_agent.py`
+- Modify: `squidbot/core/agent.py` (later task)
+
+**Step 1: Write the failing test**
+
+```python
+async def test_slash_pool_use_switches_llm_for_logical_session(...):
+    await loop.run(session, "/pool use smart", channel)
+    await loop.run(session, "hello", channel)
+    assert resolve_calls[-1] == "smart"
+```
+
+```python
+async def test_slash_model_reports_last_used_model(...):
+    await loop.run(session, "hello", channel)
+    await loop.run(session, "/model", channel)
+    assert "last_used_model" in channel.sent[-1].text
+```
+
+```python
+async def test_pool_override_resets_after_new_logical_session(...):
+    await loop.run(session, "/pool use smart", channel)
+    await loop.run(session, "/new", channel)
+    await loop.run(session, "hello", channel)
+    assert resolve_calls[-1] == "default"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_agent.py -k "slash and (pool or model)" -v`
+Expected: FAIL because AgentLoop does not yet support pool/model slash behavior.
+
+**Step 3: Write minimal implementation**
+
+Add optional constructor args and state:
+
+```python
+def __init__(..., default_pool_name: str | None = None, resolve_llm: Callable[[str], LLMPort] | None = None, list_pool_names: Callable[[], list[str]] | None = None):
+    self._default_pool_name = default_pool_name
+    self._resolve_llm = resolve_llm
+    self._list_pool_names = list_pool_names
+    self._session_pool_overrides: dict[str, str] = {}
+    self._session_last_model: dict[str, str] = {}
+```
+
+Handle slash actions:
+
+```python
+if slash_result.action == "pool":
+    # show/list/use/reset
+if slash_result.action == "model":
+    # render last used model for logical session
+```
+
+Use resolved pool for non-slash turns and capture model ID after successful LLM turn.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_agent.py -k "slash and (pool or model)" -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add squidbot/core/agent.py tests/core/test_agent.py
+git commit -m "feat(core): add session-scoped pool switching and model status slash commands"
+```
+
+### Task 4: Wire callbacks from gateway into AgentLoop
+
+**Files:**
+- Modify: `squidbot/cli/gateway.py`
+- Modify: `tests/adapters/test_llm_wiring.py`
+
+**Step 1: Write the failing test**
+
+```python
+async def test_make_agent_loop_wires_pool_resolution_callbacks(tmp_path: Path) -> None:
+    loop, _, _ = await _make_agent_loop(settings, storage_dir=tmp_path)
+    assert loop._default_pool_name == settings.llm.default_pool
+    assert callable(loop._resolve_llm)
+    assert callable(loop._list_pool_names)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/adapters/test_llm_wiring.py -v`
+Expected: FAIL because callbacks are not passed to AgentLoop yet.
+
+**Step 3: Write minimal implementation**
+
+```python
+agent_loop = AgentLoop(
+    llm=llm,
+    memory=memory,
+    registry=registry,
+    system_prompt=system_prompt,
+    default_pool_name=settings.llm.default_pool,
+    resolve_llm=functools.partial(_resolve_llm, settings),
+    list_pool_names=lambda: sorted(settings.llm.pools.keys()),
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/adapters/test_llm_wiring.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add squidbot/cli/gateway.py tests/adapters/test_llm_wiring.py
+git commit -m "feat(cli): wire model pool resolution into agent loop"
+```
+
+### Task 5: Update docs and run full quality gates
+
+**Files:**
+- Modify: `README.md`
+- Verify: `docs/plans/2026-03-04-model-pool-slash-commands-design.md`
+- Verify: `docs/plans/2026-03-04-model-pool-slash-commands-implementation-plan.md`
+
+**Step 1: Update slash command documentation**
+
+```markdown
+- `/model` — show last used model for current logical session
+- `/pool` — show active pool and source (default/override)
+- `/pool list` — list available pools
+- `/pool use <name>` — temporary pool override for current logical session
+- `/pool reset` — revert to default pool for current logical session
+```
+
+**Step 2: Run full repository checks**
+
+Run:
+- `uv run ruff check .`
+- `uv run ruff format . --check`
+- `uv run mypy squidbot/`
+- `uv run pytest`
+
+Expected: all PASS.
+
+**Step 3: Commit docs and final changes**
+
+```bash
+git add README.md docs/plans/2026-03-04-model-pool-slash-commands-design.md docs/plans/2026-03-04-model-pool-slash-commands-implementation-plan.md
+git commit -m "docs: add model and pool slash command docs"
+```

--- a/squidbot/adapters/llm/openai.py
+++ b/squidbot/adapters/llm/openai.py
@@ -130,6 +130,9 @@ class OpenAIAdapter:
     def get_last_used_model_id(self) -> str:
         """Return the model identifier used by this adapter.
 
+        Args:
+            None.
+
         Returns:
             Configured model identifier passed to this adapter.
         """

--- a/squidbot/adapters/llm/openai.py
+++ b/squidbot/adapters/llm/openai.py
@@ -127,6 +127,14 @@ class OpenAIAdapter:
 
         return kwargs
 
+    def get_last_used_model_id(self) -> str:
+        """Return the model identifier used by this adapter.
+
+        Returns:
+            Configured model identifier passed to this adapter.
+        """
+        return self._model
+
     async def chat(
         self,
         messages: list[Message],

--- a/squidbot/adapters/llm/pool.py
+++ b/squidbot/adapters/llm/pool.py
@@ -47,9 +47,14 @@ async def _pool_gen(
     last_exc: Exception | None = None
     for i, adapter in enumerate(adapters):
         try:
+            emitted = False
             async for chunk in await adapter.chat(messages, tools, stream=stream):
+                if not emitted:
+                    emitted = True
+                    if on_adapter_success is not None:
+                        on_adapter_success(adapter)
                 yield chunk
-            if on_adapter_success is not None:
+            if not emitted and on_adapter_success is not None:
                 on_adapter_success(adapter)
             return
         except Exception as exc:

--- a/squidbot/adapters/llm/pool.py
+++ b/squidbot/adapters/llm/pool.py
@@ -8,7 +8,7 @@ WARNING level so the user sees credential failures even when a fallback succeeds
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 from loguru import logger
@@ -26,6 +26,8 @@ async def _pool_gen(
     messages: list[Message],
     tools: list[ToolDefinition],
     stream: bool,
+    *,
+    on_adapter_success: Callable[[Any], None] | None = None,
 ) -> AsyncIterator[str | list[ToolCall] | tuple[list[ToolCall], str | None]]:
     """
     Async generator that tries each adapter in order, falling back on error.
@@ -47,6 +49,8 @@ async def _pool_gen(
         try:
             async for chunk in await adapter.chat(messages, tools, stream=stream):
                 yield chunk
+            if on_adapter_success is not None:
+                on_adapter_success(adapter)
             return
         except Exception as exc:
             if _is_auth_error(exc):
@@ -85,6 +89,21 @@ class PooledLLMAdapter:
         if not adapters:
             raise ValueError("PooledLLMAdapter requires at least one adapter")
         self._adapters = adapters
+        self._last_used_model_id: str | None = None
+
+    @staticmethod
+    def _extract_model_id(adapter: Any) -> str | None:
+        """Return model id from adapter introspection when available."""
+        getter = getattr(adapter, "get_last_used_model_id", None)
+        if callable(getter):
+            value = getter()
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def get_last_used_model_id(self) -> str | None:
+        """Return the model id used by the most recent successful fallback call."""
+        return self._last_used_model_id
 
     async def chat(
         self,
@@ -111,4 +130,14 @@ class PooledLLMAdapter:
         Raises:
             Exception: The last exception if all adapters fail.
         """
-        return _pool_gen(self._adapters, messages, tools, stream)
+        return _pool_gen(
+            self._adapters,
+            messages,
+            tools,
+            stream,
+            on_adapter_success=self._on_adapter_success,
+        )
+
+    def _on_adapter_success(self, adapter: Any) -> None:
+        """Store model id from the successful adapter, if introspection exists."""
+        self._last_used_model_id = self._extract_model_id(adapter)

--- a/squidbot/cli/gateway.py
+++ b/squidbot/cli/gateway.py
@@ -534,7 +534,15 @@ async def _make_agent_loop(
         )
         system_prompt = system_prompt + "\n\n" + profiles_xml
 
-    agent_loop = AgentLoop(llm=llm, memory=memory, registry=registry, system_prompt=system_prompt)
+    agent_loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=registry,
+        system_prompt=system_prompt,
+        default_pool_name=settings.llm.default_pool,
+        resolve_llm=functools.partial(_resolve_llm, settings),
+        list_pool_names=lambda: sorted(settings.llm.pools.keys()),
+    )
 
     if settings.tools.spawn.enabled:
         # SubAgentFactory holds a live reference to `registry`. SpawnTool and

--- a/squidbot/core/agent.py
+++ b/squidbot/core/agent.py
@@ -189,7 +189,11 @@ class AgentLoop:
         """Return sorted list of configured pool names."""
         if self._list_pool_names is None:
             return []
-        return sorted(set(self._list_pool_names()))
+        try:
+            return sorted(set(self._list_pool_names()))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("agent.pool: failed to list pools: {}", exc)
+            return []
 
     def _effective_pool_name(self, logical_session_id: str) -> str | None:
         """Return active pool name for a logical session."""
@@ -255,6 +259,8 @@ class AgentLoop:
         if raw == "use":
             return SLASH_POOL_USE_USAGE_TEXT
         if raw.startswith("use "):
+            if self._resolve_llm is None or self._list_pool_names is None:
+                return SLASH_POOL_UNAVAILABLE_TEXT
             pool_name = raw[4:].strip()
             if not pool_name:
                 return SLASH_POOL_USE_USAGE_TEXT
@@ -740,6 +746,8 @@ class AgentLoop:
         used_model = self._extract_last_used_model_id(selected_llm)
         if used_model is not None:
             self._session_last_model[effective_session_id] = used_model
+        else:
+            self._session_last_model.pop(effective_session_id, None)
 
         # Persist the exchange — use text_fallback to avoid storing base64 payloads.
         try:

--- a/squidbot/core/agent.py
+++ b/squidbot/core/agent.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from loguru import logger
@@ -40,6 +40,9 @@ SLASH_REMEMBER_USAGE_TEXT = "Usage: /remember <text>"
 SLASH_REMEMBER_UNAVAILABLE_TEXT = "Error: /remember unavailable (memory_write tool not configured)."
 SLASH_REMEMBER_INVALID_RESULT_TEXT = "Error: memory_write returned an invalid result."
 SLASH_ERROR_PREFIX = "Error: "
+SLASH_POOL_USE_USAGE_TEXT = "Usage: /pool use <name>"
+SLASH_POOL_UNAVAILABLE_TEXT = "Error: /pool unavailable (pool configuration is not wired)."
+SLASH_MODEL_NO_USAGE_TEXT = "No model used yet in this logical session."
 
 
 def _sanitize_log_value(value: str) -> str:
@@ -95,6 +98,10 @@ class AgentLoop:
         memory: MemoryManager,
         registry: ToolRegistry,
         system_prompt: str,
+        *,
+        default_pool_name: str | None = None,
+        resolve_llm: Callable[[str], LLMPort] | None = None,
+        list_pool_names: Callable[[], list[str]] | None = None,
     ) -> None:
         """
         Args:
@@ -102,6 +109,9 @@ class AgentLoop:
             memory: The memory manager for history and memory.md.
             registry: The tool registry with all available tools.
             system_prompt: The base system prompt (AGENTS.md content).
+            default_pool_name: Default pool name for dynamic session pool selection.
+            resolve_llm: Optional resolver mapping pool names to LLM adapters.
+            list_pool_names: Optional callback returning configured pool names.
         """
         self._llm = llm
         self._memory = memory
@@ -111,6 +121,11 @@ class AgentLoop:
         self._session_backfill_next_turn: dict[str, bool] = {}
         self._max_tracked_session_generations = MAX_TRACKED_SESSION_GENERATIONS
         self._remember_lock = asyncio.Lock()
+        self._default_pool_name = default_pool_name
+        self._resolve_llm = resolve_llm
+        self._list_pool_names = list_pool_names
+        self._session_pool_overrides: dict[str, str] = {}
+        self._session_last_model: dict[str, str] = {}
 
     def _get_session_generation(self, session_id: str) -> int:
         """Return session generation while refreshing recency order."""
@@ -169,6 +184,117 @@ class AgentLoop:
             f"- next_turn_history_backfill: {backfill_text}\n"
             f"- history_messages: {history_count}"
         )
+
+    def _available_pools(self) -> list[str]:
+        """Return sorted list of configured pool names."""
+        if self._list_pool_names is None:
+            return []
+        return sorted(set(self._list_pool_names()))
+
+    def _effective_pool_name(self, logical_session_id: str) -> str | None:
+        """Return active pool name for a logical session."""
+        override = self._session_pool_overrides.get(logical_session_id)
+        if override is not None:
+            return override
+        return self._default_pool_name
+
+    def _pool_source(self, logical_session_id: str) -> str:
+        """Return whether active pool comes from default or override."""
+        if logical_session_id in self._session_pool_overrides:
+            return "override"
+        return "default"
+
+    def _build_model_text(self, logical_session_id: str) -> str:
+        """Render deterministic `/model` output for a logical session."""
+        pool = self._effective_pool_name(logical_session_id)
+        pool_text = "(unavailable)" if pool is None else pool
+        model = self._session_last_model.get(logical_session_id)
+        if model is None:
+            return (
+                "Current model status:\n"
+                f"- active_pool: {pool_text}\n"
+                f"- pool_source: {self._pool_source(logical_session_id)}\n"
+                f"- last_used_model: {SLASH_MODEL_NO_USAGE_TEXT}"
+            )
+        return (
+            "Current model status:\n"
+            f"- active_pool: {pool_text}\n"
+            f"- pool_source: {self._pool_source(logical_session_id)}\n"
+            f"- last_used_model: {model}"
+        )
+
+    def _build_pool_text(self, logical_session_id: str) -> str:
+        """Render deterministic `/pool` output for a logical session."""
+        pool = self._effective_pool_name(logical_session_id)
+        if pool is None:
+            return "Current pool:\n- active_pool: (unavailable)\n- source: default"
+        return (
+            "Current pool:\n"
+            f"- active_pool: {pool}\n"
+            f"- source: {self._pool_source(logical_session_id)}"
+        )
+
+    def _build_pool_list_text(self) -> str:
+        """Render deterministic `/pool list` output."""
+        pools = self._available_pools()
+        if not pools:
+            return "Available pools:\n- (none configured)"
+        lines = "\n".join(f"- {name}" for name in pools)
+        return f"Available pools:\n{lines}"
+
+    def _handle_pool_command(self, logical_session_id: str, argument: str | None) -> str:
+        """Execute `/pool` subcommands and return deterministic output text."""
+        raw = (argument or "").strip()
+        if not raw:
+            return self._build_pool_text(logical_session_id)
+        if raw == "list":
+            return self._build_pool_list_text()
+        if raw == "reset":
+            self._session_pool_overrides.pop(logical_session_id, None)
+            return self._build_pool_text(logical_session_id)
+        if raw == "use":
+            return SLASH_POOL_USE_USAGE_TEXT
+        if raw.startswith("use "):
+            pool_name = raw[4:].strip()
+            if not pool_name:
+                return SLASH_POOL_USE_USAGE_TEXT
+            pools = self._available_pools()
+            if not pools:
+                return SLASH_POOL_UNAVAILABLE_TEXT
+            if pool_name not in pools:
+                return f"Error: pool '{pool_name}' not found."
+            self._session_pool_overrides[logical_session_id] = pool_name
+            return self._build_pool_text(logical_session_id)
+        return "Usage: /pool [list|use <name>|reset]"
+
+    @staticmethod
+    def _extract_last_used_model_id(llm: LLMPort) -> str | None:
+        """Return model id from adapter introspection when available."""
+        getter = getattr(llm, "get_last_used_model_id", None)
+        if callable(getter):
+            value = getter()
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def _select_llm_for_session(
+        self,
+        logical_session_id: str,
+        llm_override: LLMPort | None,
+    ) -> LLMPort:
+        """Return run-scoped LLM based on override and session pool state."""
+        if llm_override is not None:
+            return llm_override
+        if self._resolve_llm is None:
+            return self._llm
+        pool_name = self._effective_pool_name(logical_session_id)
+        if pool_name is None:
+            return self._llm
+        try:
+            return self._resolve_llm(pool_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("agent.run: failed to resolve pool '{}': {}", pool_name, exc)
+            return self._llm
 
     def _resolve_slash_actor_sender(
         self,
@@ -436,8 +562,6 @@ class AgentLoop:
             user_sender_id: Optional sender attribution used for persistence.
                 Defaults to session.sender_id.
         """
-        selected_llm = llm if llm is not None else self._llm
-
         # Derive a plain-text fallback for memory operations when input is multimodal.
         if isinstance(user_message, list):
             text_blocks = [
@@ -448,6 +572,8 @@ class AgentLoop:
             text_fallback: str = " ".join(text_blocks) if text_blocks else "[multimodal message]"
         else:
             text_fallback = user_message
+
+        effective_session_id = self._effective_session_id(session)
 
         if isinstance(user_message, str):
             slash_result = handle_slash_command(user_message)
@@ -472,6 +598,8 @@ class AgentLoop:
                     self._set_session_generation(session.id, next_generation)
                     # /new starts a fresh logical session without automatic history backfill.
                     self._session_backfill_next_turn[session.id] = False
+                    self._session_pool_overrides.pop(effective_session_id, None)
+                    self._session_last_model.pop(effective_session_id, None)
 
                 slash_text = slash_result.response_text
                 if slash_result.action == "status":
@@ -484,6 +612,13 @@ class AgentLoop:
                             exc,
                         )
                         slash_text = SLASH_STATUS_BUILD_ERROR_TEXT
+                if slash_result.action == "model":
+                    slash_text = self._build_model_text(effective_session_id)
+                if slash_result.action == "pool":
+                    slash_text = self._handle_pool_command(
+                        effective_session_id,
+                        slash_result.argument,
+                    )
                 if slash_result.action == "remember":
                     remember_note = slash_result.argument or ""
                     if not remember_note:
@@ -501,9 +636,8 @@ class AgentLoop:
                 return
 
         await channel.send_typing(session.id)
-
-        effective_session_id = self._effective_session_id(session)
         load_history = self._consume_backfill_flag(session)
+        selected_llm = self._select_llm_for_session(effective_session_id, llm)
 
         try:
             messages = await self._memory.build_messages(
@@ -602,6 +736,10 @@ class AgentLoop:
 
         await channel.send_typing(session.id, typing=False)
         await self._deliver_final_text(channel, session, final_text, outbound_metadata)
+
+        used_model = self._extract_last_used_model_id(selected_llm)
+        if used_model is not None:
+            self._session_last_model[effective_session_id] = used_model
 
         # Persist the exchange — use text_fallback to avoid storing base64 payloads.
         try:

--- a/squidbot/core/slash_commands.py
+++ b/squidbot/core/slash_commands.py
@@ -27,6 +27,11 @@ HELP_TEXT = (
     "- /help: show this help\n"
     "- /new: start a new conversation context\n"
     "- /status: show current session status\n"
+    "- /model: show last used model for this session\n"
+    "- /pool: show active pool\n"
+    "- /pool list: list available pools\n"
+    "- /pool use <name>: set pool for this session\n"
+    "- /pool reset: reset to default pool\n"
     "- /remember <text>: append a memory note"
 )
 
@@ -63,6 +68,10 @@ def handle_slash_command(text: str) -> SlashCommandResult:
         )
     if cmd == "/status":
         return SlashCommandResult(handled=True, action="status")
+    if cmd == "/model":
+        return SlashCommandResult(handled=True, action="model")
+    if cmd == "/pool":
+        return SlashCommandResult(handled=True, action="pool", argument=argument)
     if cmd == "/remember":
         if not argument:
             return SlashCommandResult(

--- a/tests/adapters/llm/test_openai_adapter.py
+++ b/tests/adapters/llm/test_openai_adapter.py
@@ -144,3 +144,9 @@ def test_build_kwargs_all_params_set() -> None:
         "reasoning_effort": "high",
         "extra_body": {"provider": {"allow_fallbacks": False}},
     }
+
+
+def test_get_last_used_model_id_returns_configured_model() -> None:
+    adapter = _make_adapter()
+
+    assert adapter.get_last_used_model_id() == "gpt-4"

--- a/tests/adapters/llm/test_pool.py
+++ b/tests/adapters/llm/test_pool.py
@@ -10,7 +10,7 @@ from squidbot.adapters.llm.pool import PooledLLMAdapter, _is_auth_error
 from squidbot.core.models import Message
 
 
-def _make_streaming_adapter(chunks: list[str]):
+def _make_streaming_adapter(chunks: list[str], *, model_id: str | None = None):
     """Build a mock LLMPort that yields the given chunks."""
 
     class StreamingAdapter:
@@ -20,6 +20,9 @@ def _make_streaming_adapter(chunks: list[str]):
                     yield chunk
 
             return _gen()
+
+        def get_last_used_model_id(self) -> str | None:
+            return model_id
 
     return StreamingAdapter()
 
@@ -73,10 +76,11 @@ async def test_first_succeeds_second_never_called():
 
 async def test_first_fails_second_called():
     a1 = _make_failing_adapter(RuntimeError("timeout"))
-    a2 = _make_streaming_adapter(["fallback"])
+    a2 = _make_streaming_adapter(["fallback"], model_id="claude-haiku")
     pool = PooledLLMAdapter([a1, a2])
     result = await _collect(pool)
     assert result == ["fallback"]
+    assert pool.get_last_used_model_id() == "claude-haiku"
 
 
 async def test_auth_error_logs_warning():
@@ -110,6 +114,17 @@ async def test_all_fail_raises_last():
     pool = PooledLLMAdapter([a1, a2])
     with pytest.raises(RuntimeError, match="second"):
         await _collect(pool)
+
+
+async def test_pool_tracks_first_adapter_model_when_no_fallback() -> None:
+    a1 = _make_streaming_adapter(["ok"], model_id="claude-opus")
+    a2 = _make_streaming_adapter(["unused"], model_id="claude-haiku")
+    pool = PooledLLMAdapter([a1, a2])
+
+    result = await _collect(pool)
+
+    assert result == ["ok"]
+    assert pool.get_last_used_model_id() == "claude-opus"
 
 
 def test_auth_error_detected_by_name():

--- a/tests/adapters/llm/test_pool.py
+++ b/tests/adapters/llm/test_pool.py
@@ -10,7 +10,7 @@ from squidbot.adapters.llm.pool import PooledLLMAdapter, _is_auth_error
 from squidbot.core.models import Message
 
 
-def _make_streaming_adapter(chunks: list[str], *, model_id: str | None = None):
+def _make_streaming_adapter(chunks: list[str], *, model_id: str | None = None) -> object:
     """Build a mock LLMPort that yields the given chunks."""
 
     class StreamingAdapter:

--- a/tests/adapters/test_llm_wiring.py
+++ b/tests/adapters/test_llm_wiring.py
@@ -90,7 +90,7 @@ async def test_make_agent_loop_wires_memory_with_history_context_messages(tmp_pa
     ):
         from squidbot.cli.gateway import _make_agent_loop
 
-        await _make_agent_loop(s, storage_dir=tmp_path)
+        loop, _, _ = await _make_agent_loop(s, storage_dir=tmp_path)
 
     call_kwargs = memory_manager_cls.call_args.kwargs
     assert call_kwargs["history_context_messages"] == 13
@@ -99,3 +99,6 @@ async def test_make_agent_loop_wires_memory_with_history_context_messages(tmp_pa
     assert "llm" not in call_kwargs
     assert "consolidation_threshold" not in call_kwargs
     assert "keep_recent_ratio" not in call_kwargs
+    assert loop._default_pool_name == s.llm.default_pool
+    assert callable(loop._resolve_llm)
+    assert callable(loop._list_pool_names)

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -1090,6 +1090,9 @@ async def test_slash_pool_reset_restores_default_pool(storage, memory):
 
 
 async def test_slash_pool_use_unknown_pool_returns_error(storage, memory):
+    def resolve_llm(pool_name: str) -> ScriptedLLM:
+        return ScriptedLLM([f"reply-{pool_name}"])
+
     llm = ScriptedLLM(["from llm"])
     channel = CollectingChannel()
     loop = AgentLoop(
@@ -1098,6 +1101,7 @@ async def test_slash_pool_use_unknown_pool_returns_error(storage, memory):
         registry=ToolRegistry(),
         system_prompt="You are a bot.",
         default_pool_name="default",
+        resolve_llm=resolve_llm,
         list_pool_names=lambda: ["default", "smart"],
     )
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -43,6 +43,18 @@ class ScriptedLLM:
         return _gen()
 
 
+class ModelReportingLLM(ScriptedLLM):
+    """LLM test double that reports a stable model id for introspection."""
+
+    def __init__(self, model_id: str, responses: list[Any]) -> None:
+        super().__init__(responses)
+        self._model_id = model_id
+
+    def get_last_used_model_id(self) -> str:
+        """Return model id used by this fake adapter."""
+        return self._model_id
+
+
 class InMemoryStorage:
     def __init__(self) -> None:
         self._history: list[Message] = []
@@ -977,6 +989,141 @@ async def test_slash_status_returns_deterministic_error_when_history_count_fails
 
     assert len(channel.sent) == 1
     assert channel.sent[0].text == "Error: unable to build session status right now."
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_model_reports_no_usage_before_llm_turn(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+        default_pool_name="default",
+        list_pool_names=lambda: ["default", "smart"],
+    )
+
+    await loop.run(SESSION, "/model", channel)
+
+    assert len(channel.sent) == 1
+    assert "last_used_model" in channel.sent[0].text
+    assert "No model used yet in this logical session." in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_pool_list_returns_configured_pools_without_llm_call(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+        default_pool_name="default",
+        list_pool_names=lambda: ["default", "smart"],
+    )
+
+    await loop.run(SESSION, "/pool list", channel)
+
+    assert len(channel.sent) == 1
+    assert "Available pools:" in channel.sent[0].text
+    assert "- default" in channel.sent[0].text
+    assert "- smart" in channel.sent[0].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_pool_use_switches_model_for_logical_session(storage, memory):
+    resolve_calls: list[str] = []
+
+    def resolve_llm(pool_name: str) -> ModelReportingLLM:
+        resolve_calls.append(pool_name)
+        return ModelReportingLLM(model_id=f"model-{pool_name}", responses=[f"reply-{pool_name}"])
+
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+        default_pool_name="default",
+        resolve_llm=resolve_llm,
+        list_pool_names=lambda: ["default", "smart"],
+    )
+
+    await loop.run(SESSION, "/pool use smart", channel)
+    await loop.run(SESSION, "hello", channel)
+    await loop.run(SESSION, "/model", channel)
+
+    assert resolve_calls == ["smart"]
+    assert channel.sent[1].text == "reply-smart"
+    assert "- last_used_model: model-smart" in channel.sent[2].text
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_pool_reset_restores_default_pool(storage, memory):
+    resolve_calls: list[str] = []
+
+    def resolve_llm(pool_name: str) -> ModelReportingLLM:
+        resolve_calls.append(pool_name)
+        return ModelReportingLLM(model_id=f"model-{pool_name}", responses=[f"reply-{pool_name}"])
+
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+        default_pool_name="default",
+        resolve_llm=resolve_llm,
+        list_pool_names=lambda: ["default", "smart"],
+    )
+
+    await loop.run(SESSION, "/pool use smart", channel)
+    await loop.run(SESSION, "/pool reset", channel)
+    await loop.run(SESSION, "hello", channel)
+
+    assert resolve_calls == ["default"]
+    assert channel.sent[-1].text == "reply-default"
+
+
+async def test_slash_pool_use_unknown_pool_returns_error(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+        default_pool_name="default",
+        list_pool_names=lambda: ["default", "smart"],
+    )
+
+    await loop.run(SESSION, "/pool use unknown", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Error: pool 'unknown' not found."
+    assert list(llm._responses) == ["from llm"]
+
+
+async def test_slash_pool_use_missing_name_returns_usage(storage, memory):
+    llm = ScriptedLLM(["from llm"])
+    channel = CollectingChannel()
+    loop = AgentLoop(
+        llm=llm,
+        memory=memory,
+        registry=ToolRegistry(),
+        system_prompt="You are a bot.",
+        default_pool_name="default",
+        list_pool_names=lambda: ["default", "smart"],
+    )
+
+    await loop.run(SESSION, "/pool use", channel)
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0].text == "Usage: /pool use <name>"
     assert list(llm._responses) == ["from llm"]
 
 

--- a/tests/core/test_slash_commands.py
+++ b/tests/core/test_slash_commands.py
@@ -17,6 +17,21 @@ def test_slash_status_sets_status_action() -> None:
     assert result.action == "status"
 
 
+def test_slash_model_sets_model_action() -> None:
+    result = handle_slash_command("/model")
+
+    assert result.handled is True
+    assert result.action == "model"
+
+
+def test_slash_pool_sets_pool_action_with_argument() -> None:
+    result = handle_slash_command("/pool use smart")
+
+    assert result.handled is True
+    assert result.action == "pool"
+    assert result.argument == "use smart"
+
+
 def test_slash_history_is_unknown_command() -> None:
     result = handle_slash_command("/history")
 


### PR DESCRIPTION
## Summary
- add new slash commands `/model`, `/pool`, `/pool list`, `/pool use <name>`, and `/pool reset` with deterministic handling in `AgentLoop`
- implement temporary per-logical-session pool overrides and runtime tracking of the last actually used model, including fallback-aware tracking in `PooledLLMAdapter`
- wire gateway pool resolution callbacks into `AgentLoop`, extend parser/tests, and update README plus design/implementation plan docs

## Testing
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run mypy squidbot/`
- `uv run pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/model` to show the last-used model for the current session.
  * Added `/pool` with `list`, `use <name>`, and `reset` to inspect and temporarily switch session-scoped pools.

* **Tests**
  * Added tests verifying `/model`, `/pool` behaviors and that model usage is reported correctly.

* **Documentation**
  * README and feature docs updated to document the new slash commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->