### PR TITLE
fix(slash-commands): use backticks instead of angle brackets in help text

### DIFF
--- a/squidbot/core/slash_commands.py
+++ b/squidbot/core/slash_commands.py
@@ -30,9 +30,9 @@ HELP_TEXT = (
     "- /model: show last used model for this session\n"
     "- /pool: show active pool\n"
     "- /pool list: list available pools\n"
-    "- /pool use <name>: set pool for this session\n"
+    "- /pool use `name`: set pool for this session\n"
     "- /pool reset: reset to default pool\n"
-    "- /remember <text>: append a memory note"
+    "- /remember `text`: append a memory note"
 )
 
 
@@ -76,7 +76,7 @@ def handle_slash_command(text: str) -> SlashCommandResult:
         if not argument:
             return SlashCommandResult(
                 handled=True,
-                response_text="Usage: /remember <text>",
+                response_text="Usage: /remember `text`",
                 is_error=True,
             )
         return SlashCommandResult(handled=True, action="remember", argument=argument)

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -1186,7 +1186,7 @@ async def test_slash_remember_requires_text_without_llm_call(storage, memory):
     await loop.run(SESSION, "/remember  ", channel)
 
     assert len(channel.sent) == 1
-    assert channel.sent[0].text == "Usage: /remember <text>"
+    assert channel.sent[0].text == "Usage: /remember `text`"
     assert list(llm._responses) == ["from llm"]
 
 

--- a/tests/core/test_slash_commands.py
+++ b/tests/core/test_slash_commands.py
@@ -46,7 +46,7 @@ def test_slash_remember_requires_text_argument() -> None:
 
     assert result.handled is True
     assert result.is_error is True
-    assert result.response_text == "Usage: /remember <text>"
+    assert result.response_text == "Usage: /remember `text`"
 
 
 def test_slash_remember_sets_argument_when_present() -> None:


### PR DESCRIPTION
## Summary

- Replace `<name>` and `<text>` with backticks in slash command help text
- Fixes Matrix rendering where angle brackets were interpreted as HTML tags

## Problem

When calling `/help` in Matrix, the help text for `/pool use <name>` and `/remember <text>` rendered incorrectly because the angle brackets were stripped as unknown HTML tags by the Matrix markdown renderer.

## Solution

Using backticks (`` `name` ``, `` `text` ``) renders as `<code>` in Matrix HTML and displays literally in CLI/Email channels.

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated help text and error messages to use code-style formatting for placeholder text with backticks for improved clarity and consistency.

* **Tests**
  * Updated test expectations to match the formatted help and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->