### PR TITLE
feat(dashboard): add local dashboard API and gateway wiring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "aioimaplib>=1.0",
     "aiosmtplib>=3.0",
     "prompt-toolkit>=3,<4",
+    "fastapi>=0.116",
+    "uvicorn>=0.35",
 ]
 
 [project.scripts]
@@ -30,6 +32,9 @@ squidbot = "squidbot.cli.main:app"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["squidbot"]
 
 [dependency-groups]
 dev = [

--- a/squidbot/adapters/dashboard/api.py
+++ b/squidbot/adapters/dashboard/api.py
@@ -279,7 +279,17 @@ def build_dashboard_app(
         try:
             page = active_runtime.log_buffer.page(limit=limit, before_cursor=before)
         except ValueError as exc:
-            return _error_response("VALIDATION_ERROR", str(exc), status_code=400)
+            logger.warning(
+                "Invalid log pagination parameters (limit={}, before={}): {}",
+                limit,
+                before,
+                exc,
+            )
+            return _error_response(
+                "VALIDATION_ERROR",
+                "Invalid log pagination parameters.",
+                status_code=400,
+            )
 
         entries = [
             {

--- a/squidbot/adapters/dashboard/api.py
+++ b/squidbot/adapters/dashboard/api.py
@@ -1,0 +1,436 @@
+"""FastAPI application factory for the dashboard adapter.
+
+This module hosts dashboard HTTP endpoints and shared request guards for
+localhost-only mutating operations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, Request
+from fastapi.responses import FileResponse, JSONResponse
+from loguru import logger
+from starlette.responses import StreamingResponse
+from starlette.staticfiles import StaticFiles
+
+from squidbot.adapters.dashboard.chat import StreamingDashboardChannel, start_ndjson_stream
+from squidbot.adapters.dashboard.logs import DashboardLogBuffer
+from squidbot.adapters.dashboard.runtime import DashboardRuntime
+from squidbot.config.schema import Settings
+from squidbot.core.models import GatewayState, Session
+
+
+def _error_response(code: str, message: str, status_code: int) -> JSONResponse:
+    """Build a consistent JSON error response payload."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": code, "message": message}},
+    )
+
+
+def _extract_host_name(host_header: str | None) -> str | None:
+    """Extract host name from Host header value, stripping optional port."""
+    if not host_header:
+        return None
+    cleaned = host_header.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("["):
+        end = cleaned.find("]")
+        if end == -1:
+            return None
+        host = cleaned[1:end]
+        return host.lower() if host else None
+    return cleaned.split(":", 1)[0].lower() or None
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    """Return True when host is localhost or a loopback IP literal."""
+    if host is None:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_loopback_origin(origin: str) -> bool:
+    """Return True when Origin header points to a loopback host."""
+    parsed = urlparse(origin)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    hostname = parsed.hostname
+    return _is_loopback_host(hostname)
+
+
+def require_local_write(request: Request, runtime: DashboardRuntime) -> JSONResponse | None:
+    """Validate local-write guard conditions for mutating dashboard requests.
+
+    Args:
+        request: Incoming HTTP request.
+        runtime: Dashboard runtime holding the active local nonce.
+
+    Returns:
+        None when the request is allowed, otherwise a JSONResponse explaining
+        why the request was rejected.
+    """
+    blocked = require_local_context(request)
+    if blocked is not None:
+        return blocked
+
+    nonce = request.headers.get("x-squidbot-local-nonce")
+    if nonce is None or not nonce:
+        return _error_response("MISSING_NONCE", "Missing X-Squidbot-Local-Nonce", status_code=403)
+    if nonce != runtime.local_nonce:
+        return _error_response("INVALID_NONCE", "Invalid X-Squidbot-Local-Nonce", status_code=403)
+    return None
+
+
+def require_local_context(request: Request) -> JSONResponse | None:
+    """Validate loopback host/origin context for local dashboard requests."""
+    host = _extract_host_name(request.headers.get("host"))
+    if not _is_loopback_host(host):
+        return _error_response("INVALID_HOST", "Host must be loopback-only", status_code=403)
+
+    origin = request.headers.get("origin")
+    if origin is not None and not _is_loopback_origin(origin):
+        return _error_response("INVALID_ORIGIN", "Origin must be loopback-only", status_code=403)
+    return None
+
+
+def _default_runtime() -> DashboardRuntime:
+    """Create a fallback runtime used by import-level app factory tests."""
+    return DashboardRuntime(
+        state=GatewayState(
+            active_sessions={},
+            channel_status=[],
+            cron_jobs_cache=[],
+            started_at=datetime.now(),
+        ),
+        log_buffer=DashboardLogBuffer(),
+        config_path=None,
+    )
+
+
+def _default_static_dir() -> Path:
+    """Return package-owned static asset directory path."""
+    return Path(__file__).with_name("static")
+
+
+def _config_error_response() -> JSONResponse:
+    """Return a consistent error when config endpoints are unavailable."""
+    return _error_response(
+        "CONFIG_UNAVAILABLE",
+        "Dashboard config endpoints require a configured config_path",
+        status_code=500,
+    )
+
+
+def _load_runtime_settings(runtime: DashboardRuntime) -> Settings | None:
+    """Load settings for config APIs when config_path is available."""
+    if runtime.config_path is None:
+        return None
+    return Settings.load(runtime.config_path)
+
+
+def _validate_config_patch(payload: Any) -> tuple[dict[str, Any] | None, str | None]:
+    """Validate incoming config patch payload and return normalized data."""
+    if not isinstance(payload, dict):
+        return None, "payload must be an object"
+
+    allowed_top = {"channels", "heartbeat"}
+    top_keys = set(payload.keys())
+    unknown_top = top_keys - allowed_top
+    if unknown_top:
+        unknown = sorted(unknown_top)[0]
+        return None, f"unknown top-level field: {unknown}"
+
+    normalized: dict[str, Any] = {}
+    if "channels" in payload:
+        channels = payload["channels"]
+        if not isinstance(channels, dict):
+            return None, "channels must be an object"
+        allowed_channels = {"matrix_enabled", "email_enabled"}
+        unknown_channels = set(channels.keys()) - allowed_channels
+        if unknown_channels:
+            unknown = sorted(unknown_channels)[0]
+            return None, f"unknown channels field: {unknown}"
+        for key, value in channels.items():
+            if not isinstance(value, bool):
+                return None, f"{key} must be a boolean"
+        normalized["channels"] = channels
+
+    if "heartbeat" in payload:
+        heartbeat = payload["heartbeat"]
+        if not isinstance(heartbeat, dict):
+            return None, "heartbeat must be an object"
+        allowed_heartbeat = {"enabled", "interval_minutes"}
+        unknown_heartbeat = set(heartbeat.keys()) - allowed_heartbeat
+        if unknown_heartbeat:
+            unknown = sorted(unknown_heartbeat)[0]
+            return None, f"unknown heartbeat field: {unknown}"
+        if "enabled" in heartbeat and not isinstance(heartbeat["enabled"], bool):
+            return None, "enabled must be a boolean"
+        if "interval_minutes" in heartbeat:
+            interval = heartbeat["interval_minutes"]
+            if type(interval) is not int or interval <= 0:
+                return None, "interval_minutes must be a positive integer"
+        normalized["heartbeat"] = heartbeat
+
+    return normalized, None
+
+
+def build_dashboard_app(
+    runtime: DashboardRuntime | None = None,
+    static_dir: Path | None = None,
+) -> FastAPI:
+    """Create the dashboard FastAPI application instance.
+
+    Args:
+        runtime: Optional runtime dependency container.
+
+    Returns:
+        A FastAPI application configured for the squidbot dashboard API.
+    """
+    app = FastAPI(title="squidbot dashboard", docs_url=None, redoc_url=None)
+    active_runtime = runtime or _default_runtime()
+    frontend_static_dir = static_dir or _default_static_dir()
+
+    assets_dir = frontend_static_dir / "assets"
+    if frontend_static_dir.exists() and (frontend_static_dir / "index.html").exists():
+        if assets_dir.exists():
+            app.mount("/assets", StaticFiles(directory=assets_dir), name="dashboard-assets")
+
+        @app.get("/")
+        async def dashboard_index() -> FileResponse:
+            """Serve packaged dashboard frontend entrypoint."""
+            return FileResponse(frontend_static_dir / "index.html")
+
+    else:
+
+        @app.get("/")
+        async def dashboard_index_missing_assets() -> JSONResponse:
+            """Return deterministic error when packaged frontend is unavailable."""
+            return _error_response(
+                "DASHBOARD_ASSETS_MISSING",
+                "Packaged dashboard static assets are missing",
+                status_code=503,
+            )
+
+    @app.get("/api/bootstrap")
+    async def bootstrap(request: Request) -> JSONResponse:
+        """Expose dashboard bootstrap metadata for local clients."""
+        blocked = require_local_context(request)
+        if blocked is not None:
+            return blocked
+        return JSONResponse(status_code=200, content={"local_nonce": active_runtime.local_nonce})
+
+    @app.get("/api/overview")
+    async def overview(request: Request) -> JSONResponse:
+        """Return high-level runtime overview for the dashboard."""
+        blocked = require_local_context(request)
+        if blocked is not None:
+            return blocked
+
+        channels = [
+            {
+                "name": item.name,
+                "enabled": item.enabled,
+                "connected": item.connected,
+                "error": item.error,
+            }
+            for item in active_runtime.state.channel_status
+        ]
+        sessions = [
+            {
+                "session_id": item.session_id,
+                "channel": item.channel,
+                "sender_id": item.sender_id,
+                "started_at": item.started_at.isoformat(),
+                "message_count": item.message_count,
+            }
+            for item in active_runtime.state.active_sessions.values()
+        ]
+        return JSONResponse(
+            status_code=200,
+            content={
+                "started_at": active_runtime.state.started_at.isoformat(),
+                "channels": channels,
+                "active_sessions": sessions,
+                "cron_jobs": len(active_runtime.state.cron_jobs_cache),
+            },
+        )
+
+    @app.get("/api/logs")
+    async def logs(request: Request, limit: int = 200, before: int | None = None) -> JSONResponse:
+        """Return paginated log entries from the dashboard buffer."""
+        blocked = require_local_context(request)
+        if blocked is not None:
+            return blocked
+        try:
+            page = active_runtime.log_buffer.page(limit=limit, before_cursor=before)
+        except ValueError as exc:
+            return _error_response("VALIDATION_ERROR", str(exc), status_code=400)
+
+        entries = [
+            {
+                "cursor": entry.cursor,
+                "ts": entry.ts.isoformat(),
+                "level": entry.level,
+                "message": entry.message,
+            }
+            for entry in page.entries
+        ]
+        return JSONResponse(
+            status_code=200,
+            content={"entries": entries, "next_before_cursor": page.next_before_cursor},
+        )
+
+    @app.get("/api/config")
+    async def read_config(request: Request) -> JSONResponse:
+        """Return a restricted editable projection of runtime config."""
+        blocked = require_local_context(request)
+        if blocked is not None:
+            return blocked
+        settings = _load_runtime_settings(active_runtime)
+        if settings is None:
+            return _config_error_response()
+
+        return JSONResponse(
+            status_code=200,
+            content={
+                "channels": {
+                    "matrix_enabled": settings.channels.matrix.enabled,
+                    "email_enabled": settings.channels.email.enabled,
+                },
+                "heartbeat": {
+                    "enabled": settings.agents.heartbeat.enabled,
+                    "interval_minutes": settings.agents.heartbeat.interval_minutes,
+                },
+            },
+        )
+
+    @app.patch("/api/config")
+    async def patch_config(request: Request) -> JSONResponse:
+        """Placeholder config patch endpoint guarded by local-write checks."""
+        blocked = require_local_write(request, active_runtime)
+        if blocked is not None:
+            return blocked
+
+        settings = _load_runtime_settings(active_runtime)
+        if settings is None:
+            return _config_error_response()
+
+        try:
+            payload = await request.json()
+        except ValueError, json.JSONDecodeError:
+            return _error_response(
+                "VALIDATION_ERROR",
+                "payload must be valid JSON",
+                status_code=400,
+            )
+        patch_data, error = _validate_config_patch(payload)
+        if error is not None:
+            return _error_response("VALIDATION_ERROR", error, status_code=400)
+
+        changed = False
+        channels = patch_data.get("channels", {}) if patch_data is not None else {}
+        heartbeat = patch_data.get("heartbeat", {}) if patch_data is not None else {}
+
+        if (
+            "matrix_enabled" in channels
+            and settings.channels.matrix.enabled != channels["matrix_enabled"]
+        ):
+            settings.channels.matrix.enabled = channels["matrix_enabled"]
+            changed = True
+        if (
+            "email_enabled" in channels
+            and settings.channels.email.enabled != channels["email_enabled"]
+        ):
+            settings.channels.email.enabled = channels["email_enabled"]
+            changed = True
+        if "enabled" in heartbeat and settings.agents.heartbeat.enabled != heartbeat["enabled"]:
+            settings.agents.heartbeat.enabled = heartbeat["enabled"]
+            changed = True
+        if (
+            "interval_minutes" in heartbeat
+            and settings.agents.heartbeat.interval_minutes != heartbeat["interval_minutes"]
+        ):
+            settings.agents.heartbeat.interval_minutes = heartbeat["interval_minutes"]
+            changed = True
+
+        config_path = active_runtime.config_path
+        if config_path is None:
+            return _config_error_response()
+        if changed:
+            settings.save(config_path)
+        return JSONResponse(
+            status_code=200,
+            content={"saved": True, "restart_required": changed},
+        )
+
+    @app.post("/api/config/restart-intent")
+    async def restart_intent(request: Request) -> JSONResponse:
+        """Record explicit operator intent to restart the gateway process."""
+        blocked = require_local_write(request, active_runtime)
+        if blocked is not None:
+            return blocked
+        active_runtime.mark_restart_requested()
+        timestamp = (
+            active_runtime.restart_requested_at.isoformat()
+            if active_runtime.restart_requested_at is not None
+            else None
+        )
+        return JSONResponse(
+            status_code=200, content={"acknowledged": True, "requested_at": timestamp}
+        )
+
+    @app.post("/api/chat/stream")
+    async def chat_stream(request: Request) -> Any:
+        """Stream operator chat responses as NDJSON frames."""
+        blocked = require_local_write(request, active_runtime)
+        if blocked is not None:
+            return blocked
+
+        agent_loop = active_runtime.agent_loop
+        if agent_loop is None:
+            return _error_response(
+                "CHAT_UNAVAILABLE", "agent loop is not configured", status_code=503
+            )
+
+        try:
+            payload = await request.json()
+        except ValueError, json.JSONDecodeError:
+            return _error_response(
+                "VALIDATION_ERROR", "payload must be valid JSON", status_code=400
+            )
+        if not isinstance(payload, dict):
+            return _error_response("VALIDATION_ERROR", "payload must be an object", status_code=400)
+
+        prompt = payload.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return _error_response("VALIDATION_ERROR", "prompt is required", status_code=400)
+
+        session = Session(channel="dashboard", sender_id="local")
+
+        async def _producer(frame_queue: asyncio.Queue[str | None]) -> None:
+            stream_channel = StreamingDashboardChannel(frame_queue)
+            try:
+                await agent_loop.run(session, prompt, stream_channel)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("dashboard.chat: stream producer failed: {}", exc)
+                frame = json.dumps({"type": "error", "message": "internal error"})
+                await frame_queue.put(f"{frame}\n")
+
+        return StreamingResponse(start_ndjson_stream(_producer), media_type="application/x-ndjson")
+
+    return app

--- a/squidbot/adapters/dashboard/api.py
+++ b/squidbot/adapters/dashboard/api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -96,7 +96,15 @@ def require_local_write(request: Request, runtime: DashboardRuntime) -> JSONResp
 
 
 def require_local_context(request: Request) -> JSONResponse | None:
-    """Validate loopback host/origin context for local dashboard requests."""
+    """Validate loopback host/origin context for local dashboard requests.
+
+    Args:
+        request: Incoming HTTP request to validate.
+
+    Returns:
+        None when host and origin are loopback-valid, otherwise a JSONResponse
+        describing why the request was rejected.
+    """
     host = _extract_host_name(request.headers.get("host"))
     if not _is_loopback_host(host):
         return _error_response("INVALID_HOST", "Host must be loopback-only", status_code=403)
@@ -114,7 +122,7 @@ def _default_runtime() -> DashboardRuntime:
             active_sessions={},
             channel_status=[],
             cron_jobs_cache=[],
-            started_at=datetime.now(),
+            started_at=datetime.now(UTC),
         ),
         log_buffer=DashboardLogBuffer(),
         config_path=None,
@@ -197,6 +205,7 @@ def build_dashboard_app(
 
     Args:
         runtime: Optional runtime dependency container.
+        static_dir: Optional override path for packaged dashboard static assets.
 
     Returns:
         A FastAPI application configured for the squidbot dashboard API.

--- a/squidbot/adapters/dashboard/chat.py
+++ b/squidbot/adapters/dashboard/chat.py
@@ -1,44 +1,82 @@
-"""Streaming channel adapter used by dashboard operator chat endpoint."""
+"""Streaming primitives for dashboard operator chat transport.
+
+This module bridges agent output chunks into NDJSON frames consumed by the
+dashboard API response stream. It provides a queue-backed channel sink and a
+stream wrapper that expose incremental assistant responses safely.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
-from contextlib import suppress
 
 from squidbot.core.models import InboundMessage, OutboundMessage
 
 
 class StreamingDashboardChannel:
-    """ChannelPort-compatible sink that writes assistant chunks to a queue."""
+    """ChannelPort-compatible sink that writes assistant chunks to a queue.
+
+    Args:
+        frame_queue: Queue used to emit NDJSON frame lines for streaming HTTP responses.
+    """
 
     streaming = True
 
     def __init__(self, frame_queue: asyncio.Queue[str | None]) -> None:
-        """Initialize with a queue that receives NDJSON frame lines."""
+        """Initialize the dashboard streaming channel.
+
+        Args:
+            frame_queue: Queue that receives NDJSON frame lines.
+
+        Returns:
+            None.
+        """
         self._frame_queue = frame_queue
 
     def receive(self) -> AsyncIterator[InboundMessage]:
-        """Dashboard chat endpoint is send-only and does not receive messages."""
+        """Reject receive because dashboard chat streaming is send-only.
+
+        Returns:
+            This method does not return and always raises NotImplementedError.
+        """
         raise NotImplementedError("StreamingDashboardChannel does not support receive()")
 
     async def send(self, message: OutboundMessage) -> None:
-        """Publish one assistant chunk as a frame line."""
+        """Publish one assistant text chunk as an NDJSON frame line.
+
+        Args:
+            message: Outbound chunk produced by the assistant.
+
+        Returns:
+            None.
+        """
         frame = json.dumps({"type": "chunk", "text": message.text})
         await self._frame_queue.put(f"{frame}\n")
 
     async def send_typing(self, session_id: str, typing: bool = True) -> None:
-        """Typing indicators are ignored for dashboard chat streams."""
+        """Ignore typing indicators for dashboard chat streams.
+
+        Args:
+            session_id: Session identifier for the typing event.
+            typing: Whether typing started or stopped.
+
+        Returns:
+            None.
+        """
         return None
 
 
 def start_ndjson_stream(
     producer: Callable[[asyncio.Queue[str | None]], Awaitable[None]],
 ) -> AsyncGenerator[str]:
-    """Run a producer and expose queue frames as an async NDJSON stream.
+    """Run a producer and expose queued frames as an async NDJSON stream.
 
-    The stream cancels the producer task when the consumer disconnects.
+    Args:
+        producer: Coroutine function that writes NDJSON frame lines to a queue.
+
+    Returns:
+        Async generator yielding NDJSON lines until producer completion or disconnect.
     """
 
     frame_queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -62,7 +100,11 @@ def start_ndjson_stream(
         finally:
             if not producer_task.done():
                 producer_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await producer_task
+            try:
+                await producer_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
 
     return _stream()

--- a/squidbot/adapters/dashboard/chat.py
+++ b/squidbot/adapters/dashboard/chat.py
@@ -1,0 +1,68 @@
+"""Streaming channel adapter used by dashboard operator chat endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
+from contextlib import suppress
+
+from squidbot.core.models import InboundMessage, OutboundMessage
+
+
+class StreamingDashboardChannel:
+    """ChannelPort-compatible sink that writes assistant chunks to a queue."""
+
+    streaming = True
+
+    def __init__(self, frame_queue: asyncio.Queue[str | None]) -> None:
+        """Initialize with a queue that receives NDJSON frame lines."""
+        self._frame_queue = frame_queue
+
+    def receive(self) -> AsyncIterator[InboundMessage]:
+        """Dashboard chat endpoint is send-only and does not receive messages."""
+        raise NotImplementedError("StreamingDashboardChannel does not support receive()")
+
+    async def send(self, message: OutboundMessage) -> None:
+        """Publish one assistant chunk as a frame line."""
+        frame = json.dumps({"type": "chunk", "text": message.text})
+        await self._frame_queue.put(f"{frame}\n")
+
+    async def send_typing(self, session_id: str, typing: bool = True) -> None:
+        """Typing indicators are ignored for dashboard chat streams."""
+        return None
+
+
+def start_ndjson_stream(
+    producer: Callable[[asyncio.Queue[str | None]], Awaitable[None]],
+) -> AsyncGenerator[str]:
+    """Run a producer and expose queue frames as an async NDJSON stream.
+
+    The stream cancels the producer task when the consumer disconnects.
+    """
+
+    frame_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    async def _wrapped_producer() -> None:
+        try:
+            await producer(frame_queue)
+        finally:
+            await frame_queue.put('{"type":"done"}\n')
+            await frame_queue.put(None)
+
+    producer_task = asyncio.create_task(_wrapped_producer())
+
+    async def _stream() -> AsyncGenerator[str]:
+        try:
+            while True:
+                item = await frame_queue.get()
+                if item is None:
+                    break
+                yield item
+        finally:
+            if not producer_task.done():
+                producer_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await producer_task
+
+    return _stream()

--- a/squidbot/adapters/dashboard/logs.py
+++ b/squidbot/adapters/dashboard/logs.py
@@ -14,7 +14,14 @@ from threading import Lock
 
 @dataclass(frozen=True)
 class DashboardLogEntry:
-    """Single structured log entry stored in the dashboard buffer."""
+    """Single structured log entry stored in the dashboard buffer.
+
+    Args:
+        cursor: Monotonic cursor for pagination.
+        ts: UTC timestamp for the log entry.
+        level: Log severity level.
+        message: Log text content.
+    """
 
     cursor: int
     ts: datetime
@@ -24,7 +31,12 @@ class DashboardLogEntry:
 
 @dataclass(frozen=True)
 class DashboardLogPage:
-    """Page response for dashboard log pagination."""
+    """Page response for dashboard log pagination.
+
+    Args:
+        entries: Ordered entries for the current page.
+        next_before_cursor: Cursor to request older entries, if available.
+    """
 
     entries: list[DashboardLogEntry]
     next_before_cursor: int | None
@@ -38,6 +50,9 @@ class DashboardLogBuffer:
 
         Args:
             max_entries: Maximum number of entries retained in memory.
+
+        Returns:
+            None.
         """
         if max_entries <= 0:
             raise ValueError("max_entries must be greater than zero")
@@ -52,6 +67,9 @@ class DashboardLogBuffer:
         Args:
             level: Log severity level.
             message: Log text content.
+
+        Returns:
+            None.
         """
         with self._lock:
             entry = DashboardLogEntry(

--- a/squidbot/adapters/dashboard/logs.py
+++ b/squidbot/adapters/dashboard/logs.py
@@ -1,0 +1,94 @@
+"""Bounded log buffer for dashboard log-tail APIs.
+
+The buffer keeps a fixed number of most-recent entries and exposes cursor-based
+paging for "load older" behavior in the web dashboard.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from threading import Lock
+
+
+@dataclass(frozen=True)
+class DashboardLogEntry:
+    """Single structured log entry stored in the dashboard buffer."""
+
+    cursor: int
+    ts: datetime
+    level: str
+    message: str
+
+
+@dataclass(frozen=True)
+class DashboardLogPage:
+    """Page response for dashboard log pagination."""
+
+    entries: list[DashboardLogEntry]
+    next_before_cursor: int | None
+
+
+class DashboardLogBuffer:
+    """Thread-safe bounded log buffer with cursor pagination."""
+
+    def __init__(self, max_entries: int = 2_000) -> None:
+        """Initialize the buffer.
+
+        Args:
+            max_entries: Maximum number of entries retained in memory.
+        """
+        if max_entries <= 0:
+            raise ValueError("max_entries must be greater than zero")
+        self._max_entries = max_entries
+        self._entries: deque[DashboardLogEntry] = deque(maxlen=max_entries)
+        self._next_cursor = 0
+        self._lock = Lock()
+
+    def append(self, *, level: str, message: str) -> None:
+        """Append a new log entry to the bounded buffer.
+
+        Args:
+            level: Log severity level.
+            message: Log text content.
+        """
+        with self._lock:
+            entry = DashboardLogEntry(
+                cursor=self._next_cursor,
+                ts=datetime.now(UTC),
+                level=level,
+                message=message,
+            )
+            self._entries.append(entry)
+            self._next_cursor += 1
+
+    def page(self, *, limit: int, before_cursor: int | None = None) -> DashboardLogPage:
+        """Return one page of log entries.
+
+        Args:
+            limit: Maximum number of entries to return.
+            before_cursor: Exclusive upper-bound cursor for older pagination.
+                The returned next_before_cursor equals the oldest cursor in the
+                current page when older entries remain.
+
+        Returns:
+            A page containing entries ordered oldest-to-newest.
+        """
+        if limit <= 0:
+            raise ValueError("limit must be greater than zero")
+
+        with self._lock:
+            entries = list(self._entries)
+
+        if before_cursor is not None:
+            entries = [entry for entry in entries if entry.cursor < before_cursor]
+
+        if not entries:
+            return DashboardLogPage(entries=[], next_before_cursor=None)
+
+        page_entries = entries[-limit:]
+        oldest_cursor = page_entries[0].cursor
+        has_older = any(entry.cursor < oldest_cursor for entry in entries)
+        next_before_cursor = oldest_cursor if has_older else None
+        return DashboardLogPage(entries=page_entries, next_before_cursor=next_before_cursor)

--- a/squidbot/adapters/dashboard/runtime.py
+++ b/squidbot/adapters/dashboard/runtime.py
@@ -28,7 +28,7 @@ def _new_local_nonce() -> str:
 class DashboardRuntime:
     """In-memory runtime dependencies shared by dashboard endpoints.
 
-    Attributes:
+    Args:
         state: Live gateway state snapshot source.
         log_buffer: Bounded in-memory log buffer for log-tail APIs.
         config_path: Optional settings file path for config endpoints.
@@ -45,5 +45,9 @@ class DashboardRuntime:
     agent_loop: AgentLoop | None = None
 
     def mark_restart_requested(self) -> None:
-        """Record the latest explicit restart intent timestamp."""
+        """Record the latest explicit restart intent timestamp.
+
+        Returns:
+            None.
+        """
         self.restart_requested_at = datetime.now(UTC)

--- a/squidbot/adapters/dashboard/runtime.py
+++ b/squidbot/adapters/dashboard/runtime.py
@@ -1,0 +1,49 @@
+"""Runtime coordination models for dashboard adapter state.
+
+This module provides lightweight dataclasses for dashboard API handlers to read
+gateway state, log buffers, and local-write safety metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from secrets import token_urlsafe
+from typing import TYPE_CHECKING
+
+from squidbot.adapters.dashboard.logs import DashboardLogBuffer
+from squidbot.core.models import GatewayState
+
+if TYPE_CHECKING:
+    from squidbot.core.agent import AgentLoop
+
+
+def _new_local_nonce() -> str:
+    """Generate a non-empty local nonce token."""
+    return token_urlsafe(24)
+
+
+@dataclass
+class DashboardRuntime:
+    """In-memory runtime dependencies shared by dashboard endpoints.
+
+    Attributes:
+        state: Live gateway state snapshot source.
+        log_buffer: Bounded in-memory log buffer for log-tail APIs.
+        config_path: Optional settings file path for config endpoints.
+        local_nonce: Runtime nonce required for mutating local requests.
+        restart_requested_at: Timestamp of explicit restart intent.
+        agent_loop: Optional agent loop used for streamed operator chat.
+    """
+
+    state: GatewayState
+    log_buffer: DashboardLogBuffer
+    config_path: Path | None
+    local_nonce: str = field(default_factory=_new_local_nonce)
+    restart_requested_at: datetime | None = None
+    agent_loop: AgentLoop | None = None
+
+    def mark_restart_requested(self) -> None:
+        """Record the latest explicit restart intent timestamp."""
+        self.restart_requested_at = datetime.now(UTC)

--- a/squidbot/cli/gateway.py
+++ b/squidbot/cli/gateway.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import asyncio
 import functools
 from collections.abc import Sequence
-from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+
+from squidbot.core.models import GatewayState
 
 if TYPE_CHECKING:
     from squidbot.adapters.persistence.jsonl import JsonlMemory
@@ -25,21 +27,6 @@ if TYPE_CHECKING:
     from squidbot.core.models import ChannelStatus, CronJob, Session, SessionInfo
     from squidbot.core.ports import ChannelPort, LLMPort
     from squidbot.core.skills import SkillMetadata
-
-
-@dataclass
-class GatewayState:
-    """
-    Live runtime state of the gateway process.
-
-    Updated by _channel_loop_with_state() and channel setup code.
-    Consumed by GatewayStatusAdapter for dashboards and status reporting.
-    """
-
-    active_sessions: dict[str, SessionInfo]
-    channel_status: list[ChannelStatus]
-    cron_jobs_cache: list[CronJob]
-    started_at: datetime = field(default_factory=datetime.now)
 
 
 class GatewayStatusAdapter:
@@ -71,6 +58,44 @@ class GatewayStatusAdapter:
     def get_skills(self) -> list[SkillMetadata]:
         """Return all discovered skills via the skills loader."""
         return self._skills_loader.list_skills()  # type: ignore[no-any-return]
+
+
+class _GatewayShutdownRequested(Exception):
+    """Internal signal to stop long-running gateway tasks in tests."""
+
+
+async def _await_shutdown_signal(shutdown_event: asyncio.Event) -> None:
+    """Block until shutdown_event is set, then raise cancellation signal."""
+    await shutdown_event.wait()
+    raise _GatewayShutdownRequested()
+
+
+def _dashboard_settings(settings: Settings) -> SimpleNamespace:
+    """Return dashboard settings, with defaults for test doubles."""
+    dashboard = getattr(settings, "dashboard", None)
+    if dashboard is None:
+        return SimpleNamespace(host="127.0.0.1", port=8765)
+    host = getattr(dashboard, "host", "127.0.0.1")
+    port = getattr(dashboard, "port", 8765)
+    return SimpleNamespace(host=host, port=port)
+
+
+async def _run_dashboard_server(runtime: Any, settings: Settings) -> None:
+    """Start the dashboard FastAPI server for the current gateway runtime."""
+    import uvicorn  # noqa: PLC0415
+
+    from squidbot.adapters.dashboard.api import build_dashboard_app  # noqa: PLC0415
+
+    dashboard_cfg = _dashboard_settings(settings)
+    app = build_dashboard_app(runtime)
+    config = uvicorn.Config(
+        app=app,
+        host=dashboard_cfg.host,
+        port=dashboard_cfg.port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
 
 
 async def _connect_mcp_servers(
@@ -634,7 +659,11 @@ def _setup_logging(level: str) -> None:
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
 
-async def _run_gateway(config_path: Path) -> None:
+async def _run_gateway(
+    config_path: Path,
+    dashboard_enabled: bool = False,
+    shutdown_event: asyncio.Event | None = None,
+) -> None:
     """Start all enabled channels concurrently.
 
     The gateway does not start a CLI channel — use `squidbot agent` for
@@ -691,15 +720,41 @@ async def _run_gateway(config_path: Path) -> None:
     # Map of channel prefix → channel instance for cron job routing
     channel_registry: dict[str, ChannelPort] = {}
 
+    dashboard_runtime: Any | None = None
+    dashboard_sink_id: int | None = None
+    if dashboard_enabled:
+        from squidbot.adapters.dashboard.logs import DashboardLogBuffer  # noqa: PLC0415
+        from squidbot.adapters.dashboard.runtime import DashboardRuntime  # noqa: PLC0415
+
+        dashboard_runtime = DashboardRuntime(
+            state=state,
+            log_buffer=DashboardLogBuffer(),
+            config_path=config_path,
+            agent_loop=agent_loop,
+        )
+
+        def _dashboard_log_sink(message: Any) -> None:
+            record = message.record
+            level_name = record["level"].name
+            text = record["message"]
+            dashboard_runtime.log_buffer.append(level=level_name, message=text)
+
+        dashboard_sink_id = logger.add(_dashboard_log_sink, level="DEBUG", format="{message}")
+
     async def on_cron_due(job: CronJob) -> None:
         """Deliver a scheduled message to the job's target channel."""
-        channel_prefix = job.channel.split(":")[0]
+        channel_prefix, separator, target = job.channel.partition(":")
+        if separator != ":" or not target:
+            logger.warning(
+                "cron: skipping job with invalid channel target '{}': {}", job.id, job.channel
+            )
+            return
         ch = channel_registry.get(channel_prefix)
         if ch is None:
             return  # target channel not active
         session = Session(
             channel=channel_prefix,
-            sender_id=job.channel.split(":", 1)[1],
+            sender_id=target,
         )
         from squidbot.adapters.tools.memory_write import MemoryWriteTool  # noqa: PLC0415
 
@@ -730,68 +785,77 @@ async def _run_gateway(config_path: Path) -> None:
     )
 
     try:
-        async with asyncio.TaskGroup() as tg:
-            tg.create_task(scheduler.run(on_due=on_cron_due))
-            tg.create_task(heartbeat.run())
-            if settings.channels.matrix.enabled:
-                from squidbot.adapters.channels.matrix import MatrixChannel  # noqa: PLC0415
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(scheduler.run(on_due=on_cron_due))
+                tg.create_task(heartbeat.run())
+                if dashboard_enabled and dashboard_runtime is not None:
+                    tg.create_task(_run_dashboard_server(dashboard_runtime, settings))
+                if shutdown_event is not None:
+                    tg.create_task(_await_shutdown_signal(shutdown_event))
+                if settings.channels.matrix.enabled:
+                    from squidbot.adapters.channels.matrix import MatrixChannel  # noqa: PLC0415
 
-                matrix_ch = MatrixChannel(
-                    config=settings.channels.matrix,
-                    owner_matrix_ids=_owner_matrix_ids(settings),
-                )
-                channel_registry["matrix"] = matrix_ch
-                state.channel_status.append(
-                    ChannelStatus(name="matrix", enabled=True, connected=True)
-                )
-                logger.info("matrix channel: starting")
-                tg.create_task(
-                    _channel_loop_with_state(
-                        matrix_ch,
-                        agent_loop,
-                        state,
-                        storage,
-                        channel_registry=channel_registry,
-                        owner_aliases=list(settings.owner.aliases),
-                        workspace=workspace,
-                        restrict_to_workspace=restrict_to_workspace,
-                        cron_mutation_lock=cron_mutation_lock,
-                        tracker=tracker,
+                    matrix_ch = MatrixChannel(
+                        config=settings.channels.matrix,
+                        owner_matrix_ids=_owner_matrix_ids(settings),
                     )
-                )
-            else:
-                state.channel_status.append(
-                    ChannelStatus(name="matrix", enabled=False, connected=False)
-                )
-                logger.info("matrix channel: disabled")
-            if settings.channels.email.enabled:
-                from squidbot.adapters.channels.email import EmailChannel  # noqa: PLC0415
+                    channel_registry["matrix"] = matrix_ch
+                    state.channel_status.append(
+                        ChannelStatus(name="matrix", enabled=True, connected=True)
+                    )
+                    logger.info("matrix channel: starting")
+                    tg.create_task(
+                        _channel_loop_with_state(
+                            matrix_ch,
+                            agent_loop,
+                            state,
+                            storage,
+                            channel_registry=channel_registry,
+                            owner_aliases=list(settings.owner.aliases),
+                            workspace=workspace,
+                            restrict_to_workspace=restrict_to_workspace,
+                            cron_mutation_lock=cron_mutation_lock,
+                            tracker=tracker,
+                        )
+                    )
+                else:
+                    state.channel_status.append(
+                        ChannelStatus(name="matrix", enabled=False, connected=False)
+                    )
+                    logger.info("matrix channel: disabled")
+                if settings.channels.email.enabled:
+                    from squidbot.adapters.channels.email import EmailChannel  # noqa: PLC0415
 
-                email_ch = EmailChannel(config=settings.channels.email)
-                channel_registry["email"] = email_ch
-                state.channel_status.append(
-                    ChannelStatus(name="email", enabled=True, connected=True)
-                )
-                logger.info("email channel: starting")
-                tg.create_task(
-                    _channel_loop_with_state(
-                        email_ch,
-                        agent_loop,
-                        state,
-                        storage,
-                        channel_registry=channel_registry,
-                        owner_aliases=list(settings.owner.aliases),
-                        workspace=workspace,
-                        restrict_to_workspace=restrict_to_workspace,
-                        cron_mutation_lock=cron_mutation_lock,
-                        tracker=tracker,
+                    email_ch = EmailChannel(config=settings.channels.email)
+                    channel_registry["email"] = email_ch
+                    state.channel_status.append(
+                        ChannelStatus(name="email", enabled=True, connected=True)
                     )
-                )
-            else:
-                state.channel_status.append(
-                    ChannelStatus(name="email", enabled=False, connected=False)
-                )
-                logger.info("email channel: disabled")
+                    logger.info("email channel: starting")
+                    tg.create_task(
+                        _channel_loop_with_state(
+                            email_ch,
+                            agent_loop,
+                            state,
+                            storage,
+                            channel_registry=channel_registry,
+                            owner_aliases=list(settings.owner.aliases),
+                            workspace=workspace,
+                            restrict_to_workspace=restrict_to_workspace,
+                            cron_mutation_lock=cron_mutation_lock,
+                            tracker=tracker,
+                        )
+                    )
+                else:
+                    state.channel_status.append(
+                        ChannelStatus(name="email", enabled=False, connected=False)
+                    )
+                    logger.info("email channel: disabled")
+        except* _GatewayShutdownRequested:
+            logger.info("gateway: shutdown signal received")
     finally:
+        if dashboard_sink_id is not None:
+            logger.remove(dashboard_sink_id)
         for conn in mcp_connections:
             await conn.close()

--- a/squidbot/cli/gateway.py
+++ b/squidbot/cli/gateway.py
@@ -74,10 +74,11 @@ def _dashboard_settings(settings: Settings) -> SimpleNamespace:
     """Return dashboard settings, with defaults for test doubles."""
     dashboard = getattr(settings, "dashboard", None)
     if dashboard is None:
-        return SimpleNamespace(host="127.0.0.1", port=8765)
+        return SimpleNamespace(enabled=False, host="127.0.0.1", port=8765)
+    enabled = bool(getattr(dashboard, "enabled", False))
     host = getattr(dashboard, "host", "127.0.0.1")
     port = getattr(dashboard, "port", 8765)
-    return SimpleNamespace(host=host, port=port)
+    return SimpleNamespace(enabled=enabled, host=host, port=port)
 
 
 async def _run_dashboard_server(runtime: Any, settings: Settings) -> None:
@@ -661,7 +662,6 @@ def _setup_logging(level: str) -> None:
 
 async def _run_gateway(
     config_path: Path,
-    dashboard_enabled: bool = False,
     shutdown_event: asyncio.Event | None = None,
 ) -> None:
     """Start all enabled channels concurrently.
@@ -676,6 +676,8 @@ async def _run_gateway(
     from squidbot.core.scheduler import CronScheduler  # noqa: PLC0415
 
     settings = Settings.load(config_path)
+    dashboard_cfg = _dashboard_settings(settings)
+    dashboard_enabled = dashboard_cfg.enabled
     _print_banner(settings)
 
     # Startup summary

--- a/squidbot/cli/main.py
+++ b/squidbot/cli/main.py
@@ -72,14 +72,6 @@ def gateway(config: Path = DEFAULT_CONFIG_PATH, log_level: str = "INFO") -> None
     asyncio.run(_run_gateway(config_path=config))
 
 
-@app.command
-def dashboard(config: Path = DEFAULT_CONFIG_PATH, log_level: str = "INFO") -> None:
-    """Start the gateway with the local dashboard web server enabled."""
-    _setup_logging(log_level)
-    asyncio.run(_run_gateway(config_path=config, dashboard_enabled=True))
-
-
-@app.command
 def status(config: Path = DEFAULT_CONFIG_PATH) -> None:
     """Show the current configuration and channel status."""
     settings = Settings.load(config)

--- a/squidbot/cli/main.py
+++ b/squidbot/cli/main.py
@@ -73,6 +73,13 @@ def gateway(config: Path = DEFAULT_CONFIG_PATH, log_level: str = "INFO") -> None
 
 
 @app.command
+def dashboard(config: Path = DEFAULT_CONFIG_PATH, log_level: str = "INFO") -> None:
+    """Start the gateway with the local dashboard web server enabled."""
+    _setup_logging(log_level)
+    asyncio.run(_run_gateway(config_path=config, dashboard_enabled=True))
+
+
+@app.command
 def status(config: Path = DEFAULT_CONFIG_PATH) -> None:
     """Show the current configuration and channel status."""
     settings = Settings.load(config)

--- a/squidbot/config/schema.py
+++ b/squidbot/config/schema.py
@@ -8,6 +8,7 @@ SQUIDBOT_ prefix (e.g., SQUIDBOT_LLM__API_KEY).
 
 from __future__ import annotations
 
+import ipaddress
 import json
 from pathlib import Path
 from typing import Any, Literal
@@ -223,8 +224,14 @@ class DashboardConfig(BaseModel):
     @model_validator(mode="after")
     def _validate_loopback_host(self) -> DashboardConfig:
         """Restrict dashboard host binding to loopback values."""
-        if self.host not in {"127.0.0.1", "localhost"}:
-            raise ValueError("dashboard.host must be loopback-only (127.0.0.1 or localhost)")
+        if self.host == "localhost":
+            return self
+        try:
+            is_loopback = ipaddress.ip_address(self.host).is_loopback
+        except ValueError:
+            is_loopback = False
+        if not is_loopback:
+            raise ValueError("dashboard.host must be loopback-only (127.0.0.1, localhost or ::1)")
         return self
 
 

--- a/squidbot/config/schema.py
+++ b/squidbot/config/schema.py
@@ -216,6 +216,7 @@ class SkillsConfig(BaseModel):
 class DashboardConfig(BaseModel):
     """Configuration for the local dashboard HTTP server."""
 
+    enabled: bool = False
     host: str = "127.0.0.1"
     port: int = 8765
 

--- a/squidbot/config/schema.py
+++ b/squidbot/config/schema.py
@@ -213,6 +213,20 @@ class SkillsConfig(BaseModel):
     )
 
 
+class DashboardConfig(BaseModel):
+    """Configuration for the local dashboard HTTP server."""
+
+    host: str = "127.0.0.1"
+    port: int = 8765
+
+    @model_validator(mode="after")
+    def _validate_loopback_host(self) -> DashboardConfig:
+        """Restrict dashboard host binding to loopback values."""
+        if self.host not in {"127.0.0.1", "localhost"}:
+            raise ValueError("dashboard.host must be loopback-only (127.0.0.1 or localhost)")
+        return self
+
+
 class OwnerAliasEntry(BaseModel):
     """A single owner alias, optionally scoped to a specific channel."""
 
@@ -249,6 +263,7 @@ class Settings(BaseModel):
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     skills: SkillsConfig = Field(default_factory=SkillsConfig)
+    dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
     owner: OwnerConfig = Field(default_factory=OwnerConfig)
 
     @model_validator(mode="after")

--- a/squidbot/core/models.py
+++ b/squidbot/core/models.py
@@ -160,3 +160,13 @@ class ChannelStatus:
     enabled: bool
     connected: bool
     error: str | None = None
+
+
+@dataclass
+class GatewayState:
+    """Live runtime state snapshot for gateway status consumers."""
+
+    active_sessions: dict[str, SessionInfo]
+    channel_status: list[ChannelStatus]
+    cron_jobs_cache: list[CronJob]
+    started_at: datetime = field(default_factory=datetime.now)

--- a/tests/adapters/test_dashboard_api.py
+++ b/tests/adapters/test_dashboard_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
@@ -21,7 +22,7 @@ def _headers(runtime: DashboardRuntime) -> dict[str, str]:
     }
 
 
-def _runtime(tmp_path) -> DashboardRuntime:
+def _runtime(tmp_path: Path) -> DashboardRuntime:
     config_path = tmp_path / "config.json"
     settings = Settings()
     settings.channels.matrix.enabled = True
@@ -50,7 +51,7 @@ def _runtime(tmp_path) -> DashboardRuntime:
     return DashboardRuntime(state=state, log_buffer=log_buffer, config_path=config_path)
 
 
-def test_get_overview_returns_channels_and_sessions(tmp_path) -> None:
+def test_get_overview_returns_channels_and_sessions(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
 
@@ -62,7 +63,7 @@ def test_get_overview_returns_channels_and_sessions(tmp_path) -> None:
     assert payload["active_sessions"][0]["session_id"] == "email:user@example.com"
 
 
-def test_get_logs_returns_paginated_entries(tmp_path) -> None:
+def test_get_logs_returns_paginated_entries(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
 
@@ -74,7 +75,7 @@ def test_get_logs_returns_paginated_entries(tmp_path) -> None:
     assert payload["next_before_cursor"] is not None
 
 
-def test_get_logs_invalid_limit_returns_generic_validation_message(tmp_path) -> None:
+def test_get_logs_invalid_limit_returns_generic_validation_message(tmp_path: Path) -> None:
     """Logs endpoint should not expose raw exception messages to clients."""
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -90,7 +91,7 @@ def test_get_logs_invalid_limit_returns_generic_validation_message(tmp_path) -> 
     }
 
 
-def test_get_config_returns_editable_projection(tmp_path) -> None:
+def test_get_config_returns_editable_projection(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
 
@@ -103,7 +104,7 @@ def test_get_config_returns_editable_projection(tmp_path) -> None:
     assert payload["heartbeat"]["interval_minutes"] == 30
 
 
-def test_patch_config_updates_allowed_fields_and_marks_restart_required(tmp_path) -> None:
+def test_patch_config_updates_allowed_fields_and_marks_restart_required(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
 
@@ -122,7 +123,7 @@ def test_patch_config_updates_allowed_fields_and_marks_restart_required(tmp_path
     assert saved.agents.heartbeat.interval_minutes == 45
 
 
-def test_patch_config_rejects_unknown_fields(tmp_path) -> None:
+def test_patch_config_rejects_unknown_fields(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
 
@@ -136,7 +137,7 @@ def test_patch_config_rejects_unknown_fields(tmp_path) -> None:
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
 
 
-def test_patch_config_rejects_boolean_interval_minutes(tmp_path) -> None:
+def test_patch_config_rejects_boolean_interval_minutes(tmp_path: Path) -> None:
     """interval_minutes must reject bool values even though bool is int-like."""
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -151,7 +152,7 @@ def test_patch_config_rejects_boolean_interval_minutes(tmp_path) -> None:
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
 
 
-def test_patch_config_rejects_malformed_json_payload(tmp_path) -> None:
+def test_patch_config_rejects_malformed_json_payload(tmp_path: Path) -> None:
     """Malformed JSON payloads should return deterministic validation errors."""
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -166,7 +167,7 @@ def test_patch_config_rejects_malformed_json_payload(tmp_path) -> None:
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
 
 
-def test_patch_config_rejects_unknown_top_level_field(tmp_path) -> None:
+def test_patch_config_rejects_unknown_top_level_field(tmp_path: Path) -> None:
     """Unknown top-level payload fields should be rejected."""
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -181,7 +182,7 @@ def test_patch_config_rejects_unknown_top_level_field(tmp_path) -> None:
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
 
 
-def test_patch_config_rejects_non_boolean_heartbeat_enabled(tmp_path) -> None:
+def test_patch_config_rejects_non_boolean_heartbeat_enabled(tmp_path: Path) -> None:
     """heartbeat.enabled must be boolean."""
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -196,7 +197,7 @@ def test_patch_config_rejects_non_boolean_heartbeat_enabled(tmp_path) -> None:
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
 
 
-def test_post_restart_intent_acknowledges_and_records_timestamp(tmp_path) -> None:
+def test_post_restart_intent_acknowledges_and_records_timestamp(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
 

--- a/tests/adapters/test_dashboard_api.py
+++ b/tests/adapters/test_dashboard_api.py
@@ -74,6 +74,22 @@ def test_get_logs_returns_paginated_entries(tmp_path) -> None:
     assert payload["next_before_cursor"] is not None
 
 
+def test_get_logs_invalid_limit_returns_generic_validation_message(tmp_path) -> None:
+    """Logs endpoint should not expose raw exception messages to clients."""
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.get("/api/logs?limit=0", headers={"host": "localhost"})
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid log pagination parameters.",
+        }
+    }
+
+
 def test_get_config_returns_editable_projection(tmp_path) -> None:
     runtime = _runtime(tmp_path)
     client = TestClient(build_dashboard_app(runtime))

--- a/tests/adapters/test_dashboard_api.py
+++ b/tests/adapters/test_dashboard_api.py
@@ -1,0 +1,191 @@
+"""Tests for dashboard core JSON API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from squidbot.adapters.dashboard.api import build_dashboard_app
+from squidbot.adapters.dashboard.logs import DashboardLogBuffer
+from squidbot.adapters.dashboard.runtime import DashboardRuntime
+from squidbot.config.schema import Settings
+from squidbot.core.models import ChannelStatus, GatewayState, SessionInfo
+
+
+def _headers(runtime: DashboardRuntime) -> dict[str, str]:
+    return {
+        "host": "localhost",
+        "origin": "http://localhost",
+        "x-squidbot-local-nonce": runtime.local_nonce,
+    }
+
+
+def _runtime(tmp_path) -> DashboardRuntime:
+    config_path = tmp_path / "config.json"
+    settings = Settings()
+    settings.channels.matrix.enabled = True
+    settings.channels.email.enabled = False
+    settings.agents.heartbeat.enabled = True
+    settings.agents.heartbeat.interval_minutes = 30
+    settings.save(config_path)
+
+    state = GatewayState(
+        active_sessions={
+            "email:user@example.com": SessionInfo(
+                session_id="email:user@example.com",
+                channel="email",
+                sender_id="user@example.com",
+                started_at=datetime(2026, 1, 1),
+                message_count=3,
+            )
+        },
+        channel_status=[ChannelStatus(name="email", enabled=True, connected=True)],
+        cron_jobs_cache=[],
+        started_at=datetime(2026, 1, 1),
+    )
+    log_buffer = DashboardLogBuffer(max_entries=20)
+    for idx in range(5):
+        log_buffer.append(level="INFO", message=f"line-{idx}")
+    return DashboardRuntime(state=state, log_buffer=log_buffer, config_path=config_path)
+
+
+def test_get_overview_returns_channels_and_sessions(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.get("/api/overview", headers={"host": "localhost"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["channels"][0]["name"] == "email"
+    assert payload["active_sessions"][0]["session_id"] == "email:user@example.com"
+
+
+def test_get_logs_returns_paginated_entries(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.get("/api/logs?limit=2", headers={"host": "localhost"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [entry["message"] for entry in payload["entries"]] == ["line-3", "line-4"]
+    assert payload["next_before_cursor"] is not None
+
+
+def test_get_config_returns_editable_projection(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.get("/api/config", headers={"host": "localhost"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["channels"]["matrix_enabled"] is True
+    assert payload["channels"]["email_enabled"] is False
+    assert payload["heartbeat"]["interval_minutes"] == 30
+
+
+def test_patch_config_updates_allowed_fields_and_marks_restart_required(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={"channels": {"email_enabled": True}, "heartbeat": {"interval_minutes": 45}},
+        headers=_headers(runtime),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"saved": True, "restart_required": True}
+
+    assert runtime.config_path is not None
+    saved = Settings.load(runtime.config_path)
+    assert saved.channels.email.enabled is True
+    assert saved.agents.heartbeat.interval_minutes == 45
+
+
+def test_patch_config_rejects_unknown_fields(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={"channels": {"unknown": True}},
+        headers=_headers(runtime),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_patch_config_rejects_boolean_interval_minutes(tmp_path) -> None:
+    """interval_minutes must reject bool values even though bool is int-like."""
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={"heartbeat": {"interval_minutes": True}},
+        headers=_headers(runtime),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_patch_config_rejects_malformed_json_payload(tmp_path) -> None:
+    """Malformed JSON payloads should return deterministic validation errors."""
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        content="{not-json",
+        headers={**_headers(runtime), "content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_patch_config_rejects_unknown_top_level_field(tmp_path) -> None:
+    """Unknown top-level payload fields should be rejected."""
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={"unknown": {"value": True}},
+        headers=_headers(runtime),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_patch_config_rejects_non_boolean_heartbeat_enabled(tmp_path) -> None:
+    """heartbeat.enabled must be boolean."""
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={"heartbeat": {"enabled": "yes"}},
+        headers=_headers(runtime),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_post_restart_intent_acknowledges_and_records_timestamp(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.post("/api/config/restart-intent", headers=_headers(runtime))
+
+    assert response.status_code == 200
+    assert response.json()["acknowledged"] is True
+    assert runtime.restart_requested_at is not None

--- a/tests/adapters/test_dashboard_api_security.py
+++ b/tests/adapters/test_dashboard_api_security.py
@@ -1,8 +1,14 @@
-"""Security and bootstrap tests for dashboard API guards."""
+"""Security and bootstrap tests for dashboard API guard behavior.
+
+This module validates localhost/write-safety checks for dashboard endpoints,
+including host, origin, and nonce requirements. It also verifies bootstrap
+nonce exposure needed by frontend mutating requests.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
@@ -23,7 +29,7 @@ def _runtime() -> DashboardRuntime:
     return DashboardRuntime(state=state, log_buffer=DashboardLogBuffer(), config_path=None)
 
 
-def _runtime_with_config(tmp_path) -> DashboardRuntime:
+def _runtime_with_config(tmp_path: Path) -> DashboardRuntime:
     runtime = _runtime()
     config_path = tmp_path / "config.json"
     Settings().save(config_path)
@@ -128,7 +134,7 @@ def test_patch_config_rejects_invalid_nonce() -> None:
     assert response.json()["error"]["code"] == "INVALID_NONCE"
 
 
-def test_patch_config_accepts_loopback_origin_with_valid_nonce(tmp_path) -> None:
+def test_patch_config_accepts_loopback_origin_with_valid_nonce(tmp_path: Path) -> None:
     """Guard should allow loopback writes when all local checks pass."""
     runtime = _runtime_with_config(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -146,7 +152,7 @@ def test_patch_config_accepts_loopback_origin_with_valid_nonce(tmp_path) -> None
     assert response.status_code == 200
 
 
-def test_patch_config_accepts_ipv6_loopback(tmp_path) -> None:
+def test_patch_config_accepts_ipv6_loopback(tmp_path: Path) -> None:
     """Guard should allow IPv6 loopback host and origin values."""
     runtime = _runtime_with_config(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -164,7 +170,7 @@ def test_patch_config_accepts_ipv6_loopback(tmp_path) -> None:
     assert response.status_code == 200
 
 
-def test_restart_intent_rejects_missing_nonce(tmp_path) -> None:
+def test_restart_intent_rejects_missing_nonce(tmp_path: Path) -> None:
     """Restart intent must require local nonce on mutating route."""
     runtime = _runtime_with_config(tmp_path)
     client = TestClient(build_dashboard_app(runtime))
@@ -178,7 +184,7 @@ def test_restart_intent_rejects_missing_nonce(tmp_path) -> None:
     assert response.json()["error"]["code"] == "MISSING_NONCE"
 
 
-def test_restart_intent_rejects_non_loopback_host(tmp_path) -> None:
+def test_restart_intent_rejects_non_loopback_host(tmp_path: Path) -> None:
     """Restart intent should reject non-loopback host values."""
     runtime = _runtime_with_config(tmp_path)
     client = TestClient(build_dashboard_app(runtime))

--- a/tests/adapters/test_dashboard_api_security.py
+++ b/tests/adapters/test_dashboard_api_security.py
@@ -1,0 +1,196 @@
+"""Security and bootstrap tests for dashboard API guards."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from squidbot.adapters.dashboard.api import build_dashboard_app
+from squidbot.adapters.dashboard.logs import DashboardLogBuffer
+from squidbot.adapters.dashboard.runtime import DashboardRuntime
+from squidbot.config.schema import Settings
+from squidbot.core.models import GatewayState
+
+
+def _runtime() -> DashboardRuntime:
+    state = GatewayState(
+        active_sessions={},
+        channel_status=[],
+        cron_jobs_cache=[],
+        started_at=datetime(2026, 1, 1),
+    )
+    return DashboardRuntime(state=state, log_buffer=DashboardLogBuffer(), config_path=None)
+
+
+def _runtime_with_config(tmp_path) -> DashboardRuntime:
+    runtime = _runtime()
+    config_path = tmp_path / "config.json"
+    Settings().save(config_path)
+    runtime.config_path = config_path
+    return runtime
+
+
+def test_bootstrap_returns_local_nonce() -> None:
+    """Bootstrap endpoint should expose the per-runtime local nonce."""
+    runtime = _runtime()
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.get("/api/bootstrap", headers={"host": "localhost"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["local_nonce"] == runtime.local_nonce
+    assert isinstance(payload["local_nonce"], str)
+    assert payload["local_nonce"]
+
+
+def test_bootstrap_rejects_non_loopback_host() -> None:
+    """Bootstrap should reject non-loopback host values."""
+    runtime = _runtime()
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.get("/api/bootstrap", headers={"host": "example.com"})
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "INVALID_HOST"
+
+
+def test_patch_config_rejects_missing_nonce() -> None:
+    """Mutating config route should reject requests without local nonce."""
+    runtime = _runtime()
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={},
+        headers={"host": "localhost", "origin": "http://localhost"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "MISSING_NONCE"
+
+
+def test_patch_config_rejects_non_loopback_origin() -> None:
+    """Mutating route should reject non-loopback origin values."""
+    runtime = _runtime()
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={},
+        headers={
+            "host": "localhost",
+            "origin": "https://evil.example",
+            "x-squidbot-local-nonce": runtime.local_nonce,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "INVALID_ORIGIN"
+
+
+def test_patch_config_rejects_non_loopback_host() -> None:
+    """Mutating route should reject non-loopback host values."""
+    runtime = _runtime()
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={},
+        headers={
+            "host": "example.com",
+            "origin": "http://localhost",
+            "x-squidbot-local-nonce": runtime.local_nonce,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "INVALID_HOST"
+
+
+def test_patch_config_rejects_invalid_nonce() -> None:
+    """Mutating route should reject incorrect local nonce values."""
+    runtime = _runtime()
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={},
+        headers={
+            "host": "localhost",
+            "origin": "http://localhost",
+            "x-squidbot-local-nonce": "wrong",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "INVALID_NONCE"
+
+
+def test_patch_config_accepts_loopback_origin_with_valid_nonce(tmp_path) -> None:
+    """Guard should allow loopback writes when all local checks pass."""
+    runtime = _runtime_with_config(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={},
+        headers={
+            "host": "localhost",
+            "origin": "http://localhost",
+            "x-squidbot-local-nonce": runtime.local_nonce,
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_patch_config_accepts_ipv6_loopback(tmp_path) -> None:
+    """Guard should allow IPv6 loopback host and origin values."""
+    runtime = _runtime_with_config(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.patch(
+        "/api/config",
+        json={},
+        headers={
+            "host": "[::1]:8765",
+            "origin": "http://[::1]:8765",
+            "x-squidbot-local-nonce": runtime.local_nonce,
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_restart_intent_rejects_missing_nonce(tmp_path) -> None:
+    """Restart intent must require local nonce on mutating route."""
+    runtime = _runtime_with_config(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.post(
+        "/api/config/restart-intent",
+        headers={"host": "localhost", "origin": "http://localhost"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "MISSING_NONCE"
+
+
+def test_restart_intent_rejects_non_loopback_host(tmp_path) -> None:
+    """Restart intent should reject non-loopback host values."""
+    runtime = _runtime_with_config(tmp_path)
+    client = TestClient(build_dashboard_app(runtime))
+
+    response = client.post(
+        "/api/config/restart-intent",
+        headers={
+            "host": "evil.example",
+            "origin": "http://localhost",
+            "x-squidbot-local-nonce": runtime.local_nonce,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "INVALID_HOST"

--- a/tests/adapters/test_dashboard_chat_stream.py
+++ b/tests/adapters/test_dashboard_chat_stream.py
@@ -1,0 +1,118 @@
+"""Tests for dashboard streamed operator chat endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from squidbot.adapters.dashboard.api import build_dashboard_app
+from squidbot.adapters.dashboard.chat import start_ndjson_stream
+from squidbot.adapters.dashboard.logs import DashboardLogBuffer
+from squidbot.adapters.dashboard.runtime import DashboardRuntime
+from squidbot.config.schema import Settings
+from squidbot.core.models import GatewayState, OutboundMessage, Session
+
+
+def _runtime_with_config_and_loop(tmp_path, loop: Any) -> DashboardRuntime:
+    config_path = tmp_path / "config.json"
+    Settings().save(config_path)
+    state = GatewayState(
+        active_sessions={},
+        channel_status=[],
+        cron_jobs_cache=[],
+        started_at=datetime(2026, 1, 1),
+    )
+    return DashboardRuntime(
+        state=state,
+        log_buffer=DashboardLogBuffer(),
+        config_path=config_path,
+        agent_loop=loop,
+    )
+
+
+def _headers(runtime: DashboardRuntime) -> dict[str, str]:
+    return {
+        "host": "localhost",
+        "origin": "http://localhost",
+        "x-squidbot-local-nonce": runtime.local_nonce,
+    }
+
+
+class ScriptedAgentLoop:
+    """Agent loop double that emits fixed chunks."""
+
+    async def run(self, session: Session, user_message: str, channel, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        assert session.channel == "dashboard"
+        assert user_message == "hello"
+        await channel.send(OutboundMessage(session=session, text="hi "))
+        await channel.send(OutboundMessage(session=session, text="there"))
+
+
+class ErrorAgentLoop:
+    """Agent loop double that raises to test error frames."""
+
+    async def run(self, session: Session, user_message: str, channel, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        raise RuntimeError("boom")
+
+
+def test_chat_stream_emits_chunks_and_done(tmp_path) -> None:
+    """Stream endpoint should emit chunk frames and terminal done frame."""
+    runtime = _runtime_with_config_and_loop(tmp_path, ScriptedAgentLoop())
+    client = TestClient(build_dashboard_app(runtime))
+
+    with client.stream(
+        "POST",
+        "/api/chat/stream",
+        json={"prompt": "hello"},
+        headers=_headers(runtime),
+    ) as response:
+        lines = [line for line in response.iter_lines() if line]
+
+    assert response.status_code == 200
+    events = [json.loads(line) for line in lines]
+    assert events[0] == {"type": "chunk", "text": "hi "}
+    assert events[1] == {"type": "chunk", "text": "there"}
+    assert events[-1] == {"type": "done"}
+
+
+def test_chat_stream_emits_error_frame_on_failure(tmp_path) -> None:
+    """Loop exceptions should be surfaced as terminal error frames."""
+    runtime = _runtime_with_config_and_loop(tmp_path, ErrorAgentLoop())
+    client = TestClient(build_dashboard_app(runtime))
+
+    with client.stream(
+        "POST",
+        "/api/chat/stream",
+        json={"prompt": "hello"},
+        headers=_headers(runtime),
+    ) as response:
+        lines = [line for line in response.iter_lines() if line]
+
+    assert response.status_code == 200
+    events = [json.loads(line) for line in lines]
+    assert events[0] == {"type": "error", "message": "internal error"}
+    assert events[-1] == {"type": "done"}
+
+
+async def test_start_ndjson_stream_cancels_producer_on_close() -> None:
+    """Closing the stream iterator should cancel an active producer task."""
+    cancelled = asyncio.Event()
+
+    async def producer(frame_queue: asyncio.Queue[str | None]) -> None:
+        await frame_queue.put('{"type":"chunk","text":"primed"}\n')
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    stream = start_ndjson_stream(producer)
+    first = await anext(stream)
+    assert json.loads(first) == {"type": "chunk", "text": "primed"}
+
+    await stream.aclose()
+    await asyncio.wait_for(cancelled.wait(), timeout=2.0)

--- a/tests/adapters/test_dashboard_chat_stream.py
+++ b/tests/adapters/test_dashboard_chat_stream.py
@@ -10,7 +10,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from squidbot.adapters.dashboard.api import build_dashboard_app
-from squidbot.adapters.dashboard.chat import start_ndjson_stream
+from squidbot.adapters.dashboard.chat import StreamingDashboardChannel, start_ndjson_stream
 from squidbot.adapters.dashboard.logs import DashboardLogBuffer
 from squidbot.adapters.dashboard.runtime import DashboardRuntime
 from squidbot.config.schema import Settings
@@ -116,3 +116,26 @@ async def test_start_ndjson_stream_cancels_producer_on_close() -> None:
 
     await stream.aclose()
     await asyncio.wait_for(cancelled.wait(), timeout=2.0)
+
+
+async def test_streaming_dashboard_channel_send_typing_noop() -> None:
+    """send_typing should be a harmless no-op for dashboard streams."""
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
+    channel = StreamingDashboardChannel(queue)
+
+    await channel.send_typing(session_id="dashboard:local", typing=True)
+
+    assert queue.empty()
+
+
+def test_streaming_dashboard_channel_receive_not_supported() -> None:
+    """Dashboard stream channel is send-only and rejects receive()."""
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
+    channel = StreamingDashboardChannel(queue)
+
+    try:
+        channel.receive()
+    except NotImplementedError as exc:
+        assert "does not support receive" in str(exc)
+    else:
+        raise AssertionError("receive() should raise NotImplementedError")

--- a/tests/adapters/test_dashboard_chat_stream.py
+++ b/tests/adapters/test_dashboard_chat_stream.py
@@ -118,6 +118,20 @@ async def test_start_ndjson_stream_cancels_producer_on_close() -> None:
     await asyncio.wait_for(cancelled.wait(), timeout=2.0)
 
 
+async def test_start_ndjson_stream_ignores_producer_exception_on_close() -> None:
+    """Closing stream should swallow producer failures during teardown."""
+
+    async def producer(frame_queue: asyncio.Queue[str | None]) -> None:
+        await frame_queue.put('{"type":"chunk","text":"primed"}\n')
+        raise RuntimeError("boom")
+
+    stream = start_ndjson_stream(producer)
+    first = await anext(stream)
+
+    assert json.loads(first) == {"type": "chunk", "text": "primed"}
+    await stream.aclose()
+
+
 async def test_streaming_dashboard_channel_send_typing_noop() -> None:
     """send_typing should be a harmless no-op for dashboard streams."""
     queue: asyncio.Queue[str | None] = asyncio.Queue()

--- a/tests/adapters/test_dashboard_imports.py
+++ b/tests/adapters/test_dashboard_imports.py
@@ -1,4 +1,9 @@
-"""Import-level tests for dashboard adapter modules."""
+"""Verify dashboard adapter import stability and app-factory defaults.
+
+This module provides lightweight import-level coverage for the dashboard API
+factory and baseline FastAPI wiring. It acts as a guardrail for adapter
+surface integrity in CI.
+"""
 
 from __future__ import annotations
 

--- a/tests/adapters/test_dashboard_imports.py
+++ b/tests/adapters/test_dashboard_imports.py
@@ -1,0 +1,17 @@
+"""Import-level tests for dashboard adapter modules."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+
+def test_build_dashboard_app_configuration() -> None:
+    """The dashboard API module exposes a configured FastAPI app factory."""
+    from squidbot.adapters.dashboard.api import build_dashboard_app
+
+    app = build_dashboard_app()
+
+    assert isinstance(app, FastAPI)
+    assert app.title == "squidbot dashboard"
+    assert app.docs_url is None
+    assert app.redoc_url is None

--- a/tests/adapters/test_dashboard_logs.py
+++ b/tests/adapters/test_dashboard_logs.py
@@ -1,4 +1,9 @@
-"""Tests for dashboard log buffering and pagination."""
+"""Tests for dashboard log buffering and pagination behavior.
+
+This module validates bounded retention, cursor pagination, and eviction
+semantics of `DashboardLogBuffer`. It protects dashboard log-tail reliability
+without unbounded memory growth.
+"""
 
 from __future__ import annotations
 

--- a/tests/adapters/test_dashboard_logs.py
+++ b/tests/adapters/test_dashboard_logs.py
@@ -1,0 +1,84 @@
+"""Tests for dashboard log buffering and pagination."""
+
+from __future__ import annotations
+
+import pytest
+
+from squidbot.adapters.dashboard.logs import DashboardLogBuffer
+
+
+def test_log_buffer_returns_newest_slice_and_cursor() -> None:
+    """The first page should include the newest entries and a cursor."""
+    log_buffer = DashboardLogBuffer(max_entries=5)
+    for index in range(5):
+        log_buffer.append(level="INFO", message=f"line-{index}")
+
+    page = log_buffer.page(limit=2)
+
+    assert [entry.message for entry in page.entries] == ["line-3", "line-4"]
+    assert page.next_before_cursor is not None
+
+
+def test_log_buffer_loads_older_entries_from_cursor() -> None:
+    """The before cursor should return older entries."""
+    log_buffer = DashboardLogBuffer(max_entries=6)
+    for index in range(6):
+        log_buffer.append(level="INFO", message=f"line-{index}")
+
+    first_page = log_buffer.page(limit=2)
+    second_page = log_buffer.page(limit=2, before_cursor=first_page.next_before_cursor)
+
+    assert [entry.message for entry in second_page.entries] == ["line-2", "line-3"]
+
+
+def test_log_buffer_pagination_is_contiguous_without_duplicates() -> None:
+    """Walking pages should return every retained entry exactly once."""
+    log_buffer = DashboardLogBuffer(max_entries=6)
+    for index in range(6):
+        log_buffer.append(level="INFO", message=f"line-{index}")
+
+    cursor: int | None = None
+    collected: list[str] = []
+    while True:
+        page = log_buffer.page(limit=2, before_cursor=cursor)
+        if not page.entries:
+            break
+        collected.extend(entry.message for entry in page.entries)
+        if page.next_before_cursor is None:
+            break
+        cursor = page.next_before_cursor
+
+    assert collected == ["line-4", "line-5", "line-2", "line-3", "line-0", "line-1"]
+
+
+def test_log_buffer_drops_oldest_when_full() -> None:
+    """Buffer capacity should evict oldest messages first."""
+    log_buffer = DashboardLogBuffer(max_entries=3)
+    for index in range(5):
+        log_buffer.append(level="INFO", message=f"line-{index}")
+
+    page = log_buffer.page(limit=10)
+
+    assert [entry.message for entry in page.entries] == ["line-2", "line-3", "line-4"]
+
+
+def test_log_buffer_rejects_non_positive_limits() -> None:
+    """Constructor and page guard clauses reject invalid limits."""
+    with pytest.raises(ValueError):
+        DashboardLogBuffer(max_entries=0)
+
+    log_buffer = DashboardLogBuffer(max_entries=3)
+    with pytest.raises(ValueError):
+        log_buffer.page(limit=0)
+
+
+def test_log_buffer_returns_empty_page_when_before_cursor_excludes_all() -> None:
+    """A before cursor older than any entry should return an empty page."""
+    log_buffer = DashboardLogBuffer(max_entries=3)
+    for index in range(3):
+        log_buffer.append(level="INFO", message=f"line-{index}")
+
+    page = log_buffer.page(limit=3, before_cursor=0)
+
+    assert page.entries == []
+    assert page.next_before_cursor is None

--- a/tests/adapters/test_gateway_dashboard_integration.py
+++ b/tests/adapters/test_gateway_dashboard_integration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -30,6 +31,56 @@ def _build_settings() -> SimpleNamespace:
         owner=SimpleNamespace(aliases=[]),
         dashboard=SimpleNamespace(host="127.0.0.1", port=8765),
     )
+
+
+def test_dashboard_settings_falls_back_to_defaults_when_missing() -> None:
+    from squidbot.cli.gateway import _dashboard_settings
+
+    settings: Any = SimpleNamespace()
+
+    dashboard = _dashboard_settings(settings)
+
+    assert dashboard.host == "127.0.0.1"
+    assert dashboard.port == 8765
+
+
+def test_dashboard_settings_uses_configured_values() -> None:
+    from squidbot.cli.gateway import _dashboard_settings
+
+    settings: Any = SimpleNamespace(dashboard=SimpleNamespace(host="localhost", port=9000))
+
+    dashboard = _dashboard_settings(settings)
+
+    assert dashboard.host == "localhost"
+    assert dashboard.port == 9000
+
+
+async def test_run_dashboard_server_uses_uvicorn_config_and_serves() -> None:
+    from squidbot.cli.gateway import _run_dashboard_server
+
+    runtime = object()
+    settings: Any = _build_settings()
+    fake_server = MagicMock()
+    fake_server.serve = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "squidbot.adapters.dashboard.api.build_dashboard_app", return_value="app"
+        ) as build_app,
+        patch("uvicorn.Config", return_value="config") as uvicorn_config,
+        patch("uvicorn.Server", return_value=fake_server) as uvicorn_server,
+    ):
+        await _run_dashboard_server(runtime, settings)
+
+    build_app.assert_called_once_with(runtime)
+    uvicorn_config.assert_called_once_with(
+        app="app",
+        host="127.0.0.1",
+        port=8765,
+        log_level="warning",
+    )
+    uvicorn_server.assert_called_once_with("config")
+    fake_server.serve.assert_awaited_once_with()
 
 
 async def _block_forever(*args: object, **kwargs: object) -> None:

--- a/tests/adapters/test_gateway_dashboard_integration.py
+++ b/tests/adapters/test_gateway_dashboard_integration.py
@@ -1,0 +1,90 @@
+"""Integration-oriented tests for gateway dashboard lifecycle wiring."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _build_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        channels=SimpleNamespace(
+            matrix=SimpleNamespace(enabled=False),
+            email=SimpleNamespace(enabled=False),
+        ),
+        agents=SimpleNamespace(
+            workspace="/tmp/squidbot-test-workspace",
+            restrict_to_workspace=False,
+            heartbeat=SimpleNamespace(
+                enabled=False,
+                interval_minutes=30,
+                active_hours_start="00:00",
+                active_hours_end="24:00",
+                timezone="local",
+                pool=None,
+            ),
+        ),
+        llm=SimpleNamespace(default_pool="default"),
+        owner=SimpleNamespace(aliases=[]),
+        dashboard=SimpleNamespace(host="127.0.0.1", port=8765),
+    )
+
+
+async def _block_forever(*args: object, **kwargs: object) -> None:
+    await asyncio.Event().wait()
+
+
+async def test_run_gateway_starts_dashboard_server_and_stops_on_shutdown() -> None:
+    from squidbot.cli.gateway import _run_gateway
+
+    settings = _build_settings()
+    fake_loop = MagicMock()
+    fake_loop.run = AsyncMock()
+    fake_conn = MagicMock()
+    fake_conn.close = AsyncMock()
+    fake_storage = MagicMock()
+    fake_storage.load_cron_jobs = AsyncMock(return_value=[])
+
+    scheduler = MagicMock()
+    scheduler.run = AsyncMock(side_effect=_block_forever)
+    heartbeat = MagicMock()
+    heartbeat.run = AsyncMock(side_effect=_block_forever)
+    dashboard_server = AsyncMock(side_effect=_block_forever)
+
+    shutdown_event = asyncio.Event()
+
+    async def _trigger_shutdown() -> None:
+        await asyncio.sleep(0.05)
+        shutdown_event.set()
+
+    with (
+        patch("squidbot.config.schema.Settings.load", return_value=settings),
+        patch("squidbot.cli.gateway._print_banner"),
+        patch(
+            "squidbot.cli.gateway._make_agent_loop",
+            new=AsyncMock(return_value=(fake_loop, [fake_conn], fake_storage)),
+        ),
+        patch("squidbot.core.scheduler.CronScheduler", return_value=scheduler),
+        patch("squidbot.core.heartbeat.HeartbeatService", return_value=heartbeat),
+        patch("squidbot.cli.gateway._run_dashboard_server", new=dashboard_server),
+        patch("squidbot.cli.gateway.logger.add", return_value=42) as logger_add,
+        patch("squidbot.cli.gateway.logger.remove") as logger_remove,
+    ):
+        await asyncio.gather(
+            _trigger_shutdown(),
+            asyncio.wait_for(
+                _run_gateway(
+                    Path("/tmp/squidbot.yaml"),
+                    dashboard_enabled=True,
+                    shutdown_event=shutdown_event,
+                ),
+                timeout=2.0,
+            ),
+        )
+
+    dashboard_server.assert_awaited_once()
+    logger_add.assert_called_once()
+    logger_remove.assert_called_once_with(42)
+    fake_conn.close.assert_awaited_once_with()

--- a/tests/adapters/test_gateway_dashboard_integration.py
+++ b/tests/adapters/test_gateway_dashboard_integration.py
@@ -29,7 +29,7 @@ def _build_settings() -> SimpleNamespace:
         ),
         llm=SimpleNamespace(default_pool="default"),
         owner=SimpleNamespace(aliases=[]),
-        dashboard=SimpleNamespace(host="127.0.0.1", port=8765),
+        dashboard=SimpleNamespace(enabled=True, host="127.0.0.1", port=8765),
     )
 
 
@@ -40,6 +40,7 @@ def test_dashboard_settings_falls_back_to_defaults_when_missing() -> None:
 
     dashboard = _dashboard_settings(settings)
 
+    assert dashboard.enabled is False
     assert dashboard.host == "127.0.0.1"
     assert dashboard.port == 8765
 
@@ -47,10 +48,13 @@ def test_dashboard_settings_falls_back_to_defaults_when_missing() -> None:
 def test_dashboard_settings_uses_configured_values() -> None:
     from squidbot.cli.gateway import _dashboard_settings
 
-    settings: Any = SimpleNamespace(dashboard=SimpleNamespace(host="localhost", port=9000))
+    settings: Any = SimpleNamespace(
+        dashboard=SimpleNamespace(enabled=True, host="localhost", port=9000)
+    )
 
     dashboard = _dashboard_settings(settings)
 
+    assert dashboard.enabled is True
     assert dashboard.host == "localhost"
     assert dashboard.port == 9000
 
@@ -126,11 +130,7 @@ async def test_run_gateway_starts_dashboard_server_and_stops_on_shutdown() -> No
         await asyncio.gather(
             _trigger_shutdown(),
             asyncio.wait_for(
-                _run_gateway(
-                    Path("/tmp/squidbot.yaml"),
-                    dashboard_enabled=True,
-                    shutdown_event=shutdown_event,
-                ),
+                _run_gateway(Path("/tmp/squidbot.yaml"), shutdown_event=shutdown_event),
                 timeout=2.0,
             ),
         )
@@ -138,4 +138,41 @@ async def test_run_gateway_starts_dashboard_server_and_stops_on_shutdown() -> No
     dashboard_server.assert_awaited_once()
     logger_add.assert_called_once()
     logger_remove.assert_called_once_with(42)
+    fake_conn.close.assert_awaited_once_with()
+
+
+async def test_run_gateway_does_not_start_dashboard_server_when_disabled() -> None:
+    from squidbot.cli.gateway import _run_gateway
+
+    settings = _build_settings()
+    settings.dashboard.enabled = False
+    fake_loop = MagicMock()
+    fake_loop.run = AsyncMock()
+    fake_conn = MagicMock()
+    fake_conn.close = AsyncMock()
+    fake_storage = MagicMock()
+    fake_storage.load_cron_jobs = AsyncMock(return_value=[])
+
+    scheduler = MagicMock()
+    scheduler.run = AsyncMock(return_value=None)
+    heartbeat = MagicMock()
+    heartbeat.run = AsyncMock(return_value=None)
+    dashboard_server = AsyncMock(return_value=None)
+
+    with (
+        patch("squidbot.config.schema.Settings.load", return_value=settings),
+        patch("squidbot.cli.gateway._print_banner"),
+        patch(
+            "squidbot.cli.gateway._make_agent_loop",
+            new=AsyncMock(return_value=(fake_loop, [fake_conn], fake_storage)),
+        ),
+        patch("squidbot.core.scheduler.CronScheduler", return_value=scheduler),
+        patch("squidbot.core.heartbeat.HeartbeatService", return_value=heartbeat),
+        patch("squidbot.cli.gateway._run_dashboard_server", new=dashboard_server),
+        patch("squidbot.cli.gateway.logger.add") as logger_add,
+    ):
+        await _run_gateway(Path("/tmp/squidbot.yaml"))
+
+    dashboard_server.assert_not_awaited()
+    logger_add.assert_not_called()
     fake_conn.close.assert_awaited_once_with()

--- a/tests/adapters/test_gateway_run_gateway.py
+++ b/tests/adapters/test_gateway_run_gateway.py
@@ -36,6 +36,7 @@ def _build_settings(
         ),
         llm=SimpleNamespace(default_pool="default"),
         owner=SimpleNamespace(aliases=owner_aliases or []),
+        dashboard=SimpleNamespace(enabled=False, host="127.0.0.1", port=8765),
     )
 
 

--- a/tests/adapters/test_gateway_run_gateway.py
+++ b/tests/adapters/test_gateway_run_gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -105,8 +106,7 @@ async def test_run_gateway_delivers_due_cron_job_to_matrix_channel() -> None:
 
     scheduler = MagicMock()
 
-    async def scheduler_run_side_effect(*, on_due: object) -> None:
-        assert callable(on_due)
+    async def scheduler_run_side_effect(*, on_due: Callable[[CronJob], Awaitable[None]]) -> None:
         await on_due(cron_job)
 
     scheduler.run = AsyncMock(side_effect=scheduler_run_side_effect)
@@ -192,3 +192,53 @@ async def test_run_gateway_passes_owner_matrix_aliases_to_channel() -> None:
     mc_ctor.assert_called_once()
     _, kwargs = mc_ctor.call_args
     assert kwargs["owner_matrix_ids"] == {"@owner1:example.org", "@owner2:example.org"}
+
+
+async def test_run_gateway_skips_cron_job_with_invalid_channel_target() -> None:
+    from squidbot.cli.gateway import _run_gateway
+
+    settings = _build_settings(matrix_enabled=True, email_enabled=False)
+    invalid_job = CronJob(
+        id="job-invalid",
+        name="Broken",
+        message="ignored",
+        schedule="every 60",
+        channel="invalid-target",
+    )
+
+    fake_loop = MagicMock()
+    fake_loop.run = AsyncMock()
+    fake_conn = MagicMock()
+    fake_conn.close = AsyncMock()
+    fake_storage = MagicMock()
+    fake_storage.load_cron_jobs = AsyncMock(return_value=[invalid_job])
+
+    scheduler = MagicMock()
+
+    async def scheduler_run_side_effect(*, on_due: Callable[[CronJob], Awaitable[None]]) -> None:
+        await on_due(invalid_job)
+
+    scheduler.run = AsyncMock(side_effect=scheduler_run_side_effect)
+    heartbeat = MagicMock()
+    heartbeat.run = AsyncMock(return_value=None)
+    matrix_channel = MagicMock()
+
+    with (
+        patch("squidbot.config.schema.Settings.load", return_value=settings),
+        patch("squidbot.cli.gateway._print_banner"),
+        patch(
+            "squidbot.cli.gateway._make_agent_loop",
+            new=AsyncMock(return_value=(fake_loop, [fake_conn], fake_storage)),
+        ),
+        patch("squidbot.core.scheduler.CronScheduler", return_value=scheduler),
+        patch("squidbot.core.heartbeat.HeartbeatService", return_value=heartbeat),
+        patch("squidbot.adapters.channels.matrix.MatrixChannel", return_value=matrix_channel),
+        patch(
+            "squidbot.cli.gateway._channel_loop_with_state",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await _run_gateway(Path("/tmp/squidbot.yaml"))
+
+    fake_loop.run.assert_not_awaited()
+    fake_conn.close.assert_awaited_once_with()

--- a/tests/cli/test_main_dashboard.py
+++ b/tests/cli/test_main_dashboard.py
@@ -1,4 +1,8 @@
-"""Tests for the dashboard CLI command wiring."""
+"""Validate gateway CLI command wiring in squidbot.
+
+This module verifies command wiring after dashboard startup became config-driven
+under the gateway command.
+"""
 
 from __future__ import annotations
 
@@ -6,11 +10,11 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 
-def test_dashboard_command_runs_gateway_with_dashboard_enabled() -> None:
-    """dashboard() wires logging and gateway startup with dashboard mode."""
+def test_gateway_command_runs_gateway_without_dashboard_flag() -> None:
+    """gateway() wires logging and gateway startup without extra flags."""
     from squidbot.cli import main
 
-    config_path = Path("/tmp/squidbot-dashboard.json")
+    config_path = Path("/tmp/squidbot-gateway.json")
 
     with (
         patch("squidbot.cli.main._setup_logging") as setup_logging,
@@ -19,8 +23,15 @@ def test_dashboard_command_runs_gateway_with_dashboard_enabled() -> None:
             "squidbot.cli.main._run_gateway", new=Mock(return_value="gateway-coro")
         ) as run_gateway,
     ):
-        main.dashboard(config=config_path, log_level="DEBUG")
+        main.gateway(config=config_path, log_level="DEBUG")
 
     setup_logging.assert_called_once_with("DEBUG")
-    run_gateway.assert_called_once_with(config_path=config_path, dashboard_enabled=True)
+    run_gateway.assert_called_once_with(config_path=config_path)
     asyncio_run.assert_called_once_with("gateway-coro")
+
+
+def test_main_module_has_no_dashboard_command_function() -> None:
+    """main module should no longer expose a dashboard command entrypoint."""
+    from squidbot.cli import main
+
+    assert not hasattr(main, "dashboard")

--- a/tests/cli/test_main_dashboard.py
+++ b/tests/cli/test_main_dashboard.py
@@ -1,0 +1,26 @@
+"""Tests for the dashboard CLI command wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def test_dashboard_command_runs_gateway_with_dashboard_enabled() -> None:
+    """dashboard() wires logging and gateway startup with dashboard mode."""
+    from squidbot.cli import main
+
+    config_path = Path("/tmp/squidbot-dashboard.json")
+
+    with (
+        patch("squidbot.cli.main._setup_logging") as setup_logging,
+        patch("squidbot.cli.main.asyncio.run") as asyncio_run,
+        patch(
+            "squidbot.cli.main._run_gateway", new=Mock(return_value="gateway-coro")
+        ) as run_gateway,
+    ):
+        main.dashboard(config=config_path, log_level="DEBUG")
+
+    setup_logging.assert_called_once_with("DEBUG")
+    run_gateway.assert_called_once_with(config_path=config_path, dashboard_enabled=True)
+    asyncio_run.assert_called_once_with("gateway-coro")

--- a/tests/config/test_dashboard_schema.py
+++ b/tests/config/test_dashboard_schema.py
@@ -1,0 +1,22 @@
+"""Tests for dashboard server configuration schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from squidbot.config.schema import Settings
+
+
+def test_dashboard_settings_defaults_to_loopback() -> None:
+    """Dashboard defaults should be local-only with a deterministic port."""
+    settings = Settings()
+
+    assert settings.dashboard.host == "127.0.0.1"
+    assert settings.dashboard.port == 8765
+
+
+def test_dashboard_settings_reject_non_loopback_host() -> None:
+    """Dashboard host must remain loopback-only in v1."""
+    with pytest.raises(ValidationError):
+        Settings.model_validate({"dashboard": {"host": "0.0.0.0"}})

--- a/tests/config/test_dashboard_schema.py
+++ b/tests/config/test_dashboard_schema.py
@@ -1,4 +1,9 @@
-"""Tests for dashboard server configuration schema."""
+"""Tests for dashboard server configuration schema.
+
+This module validates loopback-only host constraints and default dashboard
+network settings in `Settings`. It protects the local-only security posture of
+the dashboard feature during configuration loading.
+"""
 
 from __future__ import annotations
 
@@ -21,3 +26,10 @@ def test_dashboard_settings_reject_non_loopback_host() -> None:
     """Dashboard host must remain loopback-only in v1."""
     with pytest.raises(ValidationError):
         Settings.model_validate({"dashboard": {"host": "0.0.0.0"}})
+
+
+def test_dashboard_settings_accept_ipv6_loopback_host() -> None:
+    """Dashboard host accepts IPv6 loopback literals."""
+    settings = Settings.model_validate({"dashboard": {"host": "::1"}})
+
+    assert settings.dashboard.host == "::1"

--- a/tests/config/test_dashboard_schema.py
+++ b/tests/config/test_dashboard_schema.py
@@ -12,6 +12,7 @@ def test_dashboard_settings_defaults_to_loopback() -> None:
     """Dashboard defaults should be local-only with a deterministic port."""
     settings = Settings()
 
+    assert settings.dashboard.enabled is False
     assert settings.dashboard.host == "127.0.0.1"
     assert settings.dashboard.port == 8765
 

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -376,6 +385,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -1369,6 +1394,7 @@ dependencies = [
     { name = "cronsim" },
     { name = "cyclopts" },
     { name = "duckduckgo-search" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "matrix-nio", extra = ["e2e"] },
@@ -1382,6 +1408,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "rich" },
     { name = "ruamel-yaml" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -1400,6 +1427,7 @@ requires-dist = [
     { name = "cronsim", specifier = ">=2.0" },
     { name = "cyclopts", specifier = ">=3.0" },
     { name = "duckduckgo-search", specifier = ">=8.0" },
+    { name = "fastapi", specifier = ">=0.116" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "matrix-nio", extras = ["e2e"], specifier = ">=0.25" },
@@ -1413,6 +1441,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
+    { name = "uvicorn", specifier = ">=0.35" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- add a local dashboard API surface for overview, logs, config projection, restart intent, and streamed operator chat
- wire dashboard runtime state into the gateway and config so the API can run behind loopback-only safeguards
- add backend-focused tests for API behavior, security checks, chat streaming, logs, gateway integration, and config validation

## Why
- establish the backend/operator API first without coupling review scope to the frontend dashboard UI
- make it possible to review API shape, gateway wiring, and local-write protections independently
- defer UI/form-factor decisions for a later PR

## Testing
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run mypy squidbot/`
- `uv run pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard web interface with real-time logs, system overview, and configuration management
  * Integrated chat streaming capability with local-only security (loopback addresses only)

* **Breaking Changes**
  * Removed status CLI subcommand

* **Dependencies**
  * Added fastapi and uvicorn runtime dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->